### PR TITLE
Added code coverage check with codecov

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -30,10 +30,18 @@ jobs:
       run: ./gradlew spotlessCheck -x spotlessApply
 
     - name: Build with Gradle Wrapper
-      run: ./gradlew build
+      run: ./gradlew build koverXmlReport
+
+    - name: Upload Code Coverage
+    - uses: codecov/codecov-action@v4
+      with:
+        fail_ci_if_error: true
+        files: ./build/reports/kover/report.xml
+        token: ${{ secrets.CODECOV_TOKEN }}
+        verbose: true
 
   dependency-submission:
-
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -33,7 +33,7 @@ jobs:
       run: ./gradlew build koverXmlReport
 
     - name: Upload Code Coverage
-    - uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v4
       with:
         fail_ci_if_error: true
         files: ./build/reports/kover/report.xml

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # kotlin-csaf
 
-A kotlin implementation of the CSAF standard.
+[![Actions Status](https://github.com/csaf-sbom/kotlin-csaf/workflows/build/badge.svg)](https://github.com/csaf-sbom/kotlin-csaf/actions) [![codecov](https://codecov.io/gh/csaf-sbom/kotlin-csaf/graph/badge.svg?token=XGBIJHSLUK)](https://codecov.io/gh/csaf-sbom/kotlin-csaf) 
+
+A kotlin implementation of the CSAF standard. This library is currently being developed. We will continuously update this README file with the progress.

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -11,4 +11,5 @@ repositories {
 dependencies {
     implementation(libs.kotlin.gradle.plugin)
     implementation(libs.spotless.gradle)
+    implementation(libs.kover.gradle)
 }

--- a/build-logic/src/main/kotlin/buildlogic.kotlin-common-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/buildlogic.kotlin-common-conventions.gradle.kts
@@ -2,13 +2,20 @@ plugins {
     // Apply the org.jetbrains.kotlin.jvm Plugin to add support for Kotlin.
     id("org.jetbrains.kotlin.jvm")
 
-    // Apply formatting convertions
+    // Apply formatting conventions
     id("buildlogic.kotlin-formatting-conventions")
+
+    // Apply code coverage plugin
+    id("org.jetbrains.kotlinx.kover")
 }
 
 repositories {
     // Use Maven Central for resolving dependencies.
     mavenCentral()
+}
+
+dependencies {
+    testImplementation(kotlin("test"))
 }
 
 testing {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,9 @@
+plugins {
+    id("buildlogic.kotlin-common-conventions")
+}
+
+dependencies {
+    // This merges all our individual kover results into the root project
+    kover(project(":csaf-import"))
+    kover(project(":csaf-schema-codegen"))
+}

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  range: "75...95"
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0.5%
+    patch:
+      default:
+        target: 75%

--- a/csaf-import/src/test/kotlin/com/github/csaf/generated/AggregatorTest.kt
+++ b/csaf-import/src/test/kotlin/com/github/csaf/generated/AggregatorTest.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2024, The Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.github.csaf.generated
+
+import com.github.csaf.generated.Aggregator_json.Metadata_t
+import com.github.csaf.generated.Aggregator_json.Publisher
+import java.net.URI
+import java.time.OffsetDateTime
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+
+class AggregatorTest {
+    @Test
+    fun testObject() {
+        var doc =
+            Aggregator_json(
+                aggregator =
+                    Aggregator_json.Aggregator(
+                        category = Aggregator_json.Category.aggregator,
+                        name = "Test Aggregator",
+                        namespace = URI("example.com"),
+                    ),
+                aggregator_version = "2.0",
+                canonical_url = URI("example.com/aggregator.json"),
+                csaf_providers =
+                    setOf(
+                        Aggregator_json.Csaf_provider(
+                            metadata =
+                                Metadata_t(
+                                    last_updated = OffsetDateTime.now(),
+                                    publisher =
+                                        Publisher(
+                                            category = Aggregator_json.Category1.vendor,
+                                            name = "Test Aggregator",
+                                            namespace = URI("example.com"),
+                                        ),
+                                    url = URI("example.com/publisher.json")
+                                ),
+                        ),
+                    ),
+                last_updated = OffsetDateTime.now(),
+            )
+        assertNotNull(doc)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,9 +8,11 @@ spotless = "6.25.0"
 codegen = { group = "net.pwall.json", name = "json-kotlin-schema-codegen", version.ref= "codegen" }
 ktor-client-core = { group = "io.ktor", name = "ktor-client-core", version.ref = "ktor" }
 ktor-client-java = { group = "io.ktor", name = "ktor-client-java", version.ref = "ktor" }
+
+# plugins
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 spotless-gradle = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless" }
+kover-gradle = { module = "org.jetbrains.kotlinx:kover-gradle-plugin", version = "0.8.0" }
 
 [bundles]
 ktor-client = ["ktor-client-core", "ktor-client-java"]
-


### PR DESCRIPTION
This PR adds code coverage checks with kover that are uploaded to codecov.

It currently sets the minimum code coverage to 75 %. We are aiming at a much higher rate at the end (near 90 % ideally), but in order to not slow down development, we will gradually increate this target, starting from 75 %.