### PR TITLE
Integrate kotlin-json-codegen plugin without hardcoded versions

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -6,10 +6,12 @@ plugins {
 repositories {
     // Use the plugin portal to apply community plugins in convention plugins.
     gradlePluginPortal()
+    maven { url = uri("https://jitpack.io") }
 }
 
 dependencies {
     implementation(libs.kotlin.gradle.plugin)
     implementation(libs.spotless.gradle)
     implementation(libs.kover.gradle)
+    implementation(libs.kotlin.json.codegen)
 }

--- a/csaf-schema/build.gradle.kts
+++ b/csaf-schema/build.gradle.kts
@@ -3,7 +3,7 @@ import net.pwall.json.kotlin.codegen.gradle.JSONSchemaCodegenTask
 
 plugins {
     id("buildlogic.kotlin-library-conventions")
-    id("net.pwall.json.json-kotlin") version "0.108.2"
+    id("net.pwall.json.json-kotlin")
 }
 
 configure<JSONSchemaCodegen> {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,11 +1,10 @@
 [versions]
 kotlin = "2.0.20"
-codegen = "0.108"
+codegen = "0.108.2"
 ktor = "2.3.12"
 spotless = "6.25.0"
 
 [libraries]
-codegen = { group = "net.pwall.json", name = "json-kotlin-schema-codegen", version.ref= "codegen" }
 ktor-client-core = { group = "io.ktor", name = "ktor-client-core", version.ref = "ktor" }
 ktor-client-java = { group = "io.ktor", name = "ktor-client-java", version.ref = "ktor" }
 
@@ -13,6 +12,7 @@ ktor-client-java = { group = "io.ktor", name = "ktor-client-java", version.ref =
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 spotless-gradle = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless" }
 kover-gradle = { module = "org.jetbrains.kotlinx:kover-gradle-plugin", version = "0.8.3" }
+kotlin-json-codegen = { module = "com.github.csaf-sbom:json-kotlin-gradle", version.ref = "codegen" }
 
 [bundles]
 ktor-client = ["ktor-client-core", "ktor-client-java"]

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,13 +1,6 @@
 pluginManagement {
     // Include 'plugins build' to define convention plugins.
     includeBuild("build-logic")
-    resolutionStrategy {
-        eachPlugin {
-            if (requested.id.namespace == "net.pwall.json") {
-                useModule("com.github.csaf-sbom:json-kotlin-gradle:0.108.2")
-            }
-        }
-    }
     repositories {
         gradlePluginPortal()
         maven { url = uri("https://jitpack.io") }


### PR DESCRIPTION
This PR integrates our fork of the `kotlin-json-codegen` via the convention plugin build dependencies, thus circumventing ugly resolution hacks and hardcoded values in `settings.kts`.
Artifact coordinates and version are only specified in `libs.versions.toml` now, as it should be.
