### PR TITLE
Hotfix: do not create GitHub Release

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -71,15 +71,6 @@ jobs:
         ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PASSWORD }}
         ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
         ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
-    - name: Create Release
-      if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'beta') && !contains(github.ref, 'alpha')
-      id: create_release
-      uses: softprops/action-gh-release@v2
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        name: ${{ env.version }}
-        draft: false
-        prerelease: false
 
   dependency-submission:
     if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
Creating a GH release does not seem to work, but is also not necessary since we already do it manually.
