### PR TITLE
Implemented Document Stream

### DIFF
--- a/csaf-import/src/main/kotlin/io/github/csaf/sbom/retrieval/Main.kt
+++ b/csaf-import/src/main/kotlin/io/github/csaf/sbom/retrieval/Main.kt
@@ -27,13 +27,13 @@ fun main(args: Array<String>) {
             .onSuccess { provider ->
                 println("Discovered provider-metadata.json @ ${provider.json.canonical_url}")
                 // Retrieve all documents from all feeds. Note: we currently only support index.txt
-                provider.fetchDocuments().forEach {
-                    it.onSuccess { doc ->
+                for (result in provider.fetchDocuments()) {
+                    result.onSuccess { doc ->
                         // The resulting document is a "Csaf" type, which contains the
                         // representation defined in the JSON schema
                         println("Fetched document with ID ${doc.json.document.tracking.id}")
                     }
-                    it.onFailure { ex ->
+                    result.onFailure { ex ->
                         println("Could not fetch document: ${ex.message}, ${ex.cause}")
                     }
                 }

--- a/csaf-import/src/main/kotlin/io/github/csaf/sbom/retrieval/Validatable.kt
+++ b/csaf-import/src/main/kotlin/io/github/csaf/sbom/retrieval/Validatable.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2024, The Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.github.csaf.sbom.retrieval
+
+import io.github.csaf.sbom.validation.Role
+import io.github.csaf.sbom.validation.ValidationContext
+import io.github.csaf.sbom.validation.ValidationFailed
+
+interface Validatable {
+    val role: Role
+
+    /**
+     * Validates this [Validatable] according to the CSAF standard.
+     *
+     * @param validationContext The validation context used for validation.
+     */
+    fun validate(validationContext: ValidationContext) {
+        role.checkRole(validationContext).let { vr ->
+            if (vr is ValidationFailed) {
+                throw vr.toException()
+            }
+        }
+    }
+}

--- a/csaf-import/src/test/java/io/github/csaf/sbom/retrieval/RetrievedProviderJavaTest.java
+++ b/csaf-import/src/test/java/io/github/csaf/sbom/retrieval/RetrievedProviderJavaTest.java
@@ -37,8 +37,13 @@ public class RetrievedProviderJavaTest {
     @Test
     public void testRetrievedProviderJava() throws InterruptedException, ExecutionException {
         final var provider = RetrievedProvider.fromAsync("example.com").get();
-        final var documentResults = provider.fetchDocumentsAsync().get();
-
+        final var expectedDocumentCount = provider.countExpectedDocumentsBlocking();
+        assertEquals(
+                3,
+                expectedDocumentCount,
+                "Expected 3 documents"
+        );
+        final var documentResults = provider.streamDocuments().toList();
         assertEquals(
                 4,
                 documentResults.size(),

--- a/csaf-import/src/test/kotlin/io/github/csaf/sbom/retrieval/RetrievedProviderTest.kt
+++ b/csaf-import/src/test/kotlin/io/github/csaf/sbom/retrieval/RetrievedProviderTest.kt
@@ -18,6 +18,7 @@ package io.github.csaf.sbom.retrieval
 
 import io.github.csaf.sbom.validation.ValidationException
 import kotlin.test.*
+import kotlinx.coroutines.channels.toList
 import kotlinx.coroutines.test.runTest
 
 class RetrievedProviderTest {
@@ -50,13 +51,17 @@ class RetrievedProviderTest {
     @Test
     fun testRetrievedProviderEmptyIndex() = runTest {
         val provider = RetrievedProvider.from("no-distributions.com").getOrThrow()
-        val documentResults = provider.fetchDocuments()
-        assertEquals(0, documentResults.size)
+        val expectedDocumentCount = provider.countExpectedDocuments()
+        assertEquals(0, expectedDocumentCount)
+        val documentResults = provider.fetchDocuments().toList()
+        assertTrue(documentResults.isEmpty())
     }
 
     private suspend fun providerTest(url: String) {
         val provider = RetrievedProvider.from(url).getOrThrow()
-        val documentResults = provider.fetchDocuments()
+        val expectedDocumentCount = provider.countExpectedDocuments()
+        assertEquals(3, expectedDocumentCount, "Expected 3 documents")
+        val documentResults = provider.fetchDocuments().toList()
         assertEquals(
             4,
             documentResults.size,


### PR DESCRIPTION
Implemented streaming of `Document`s, i.e. `Result`s from `fetchDocument()` and related functions can now be processed on-the-fly.
