### PR TITLE
Added CVSS-related tests (6.1.8, 6.1.9, 6.1.10)

### DIFF
--- a/csaf-cvss/build.gradle.kts
+++ b/csaf-cvss/build.gradle.kts
@@ -1,0 +1,14 @@
+plugins {
+    id("buildlogic.kotlin-library-conventions")
+}
+
+mavenPublishing {
+    pom {
+        name.set("Kotlin CSAF - CVSS Module")
+        description.set("CVSS calculation utilities for Kotlin CSAF")
+    }
+}
+
+dependencies {
+    implementation(project(":csaf-schema"))
+}

--- a/csaf-cvss/src/main/kotlin/io/github/csaf/sbom/cvss/Calculation.kt
+++ b/csaf-cvss/src/main/kotlin/io/github/csaf/sbom/cvss/Calculation.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024, The Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.github.csaf.sbom.cvss
+
+/**
+ * Represents a CVSS score calculation. This needs to be implemented by the respective standard
+ * versions.
+ */
+interface CvssCalculation {
+
+    val metrics: Map<String, String>
+
+    fun calculateBaseScore(): Double
+
+    fun calculateTemporalScore(): Double
+
+    fun calculateEnvironmentalScore(): Double
+}

--- a/csaf-cvss/src/main/kotlin/io/github/csaf/sbom/cvss/Extensions.kt
+++ b/csaf-cvss/src/main/kotlin/io/github/csaf/sbom/cvss/Extensions.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2024, The Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.github.csaf.sbom.cvss
+
+import io.github.csaf.sbom.schema.generated.Csaf.BaseSeverity
+
+fun Double.toSeverity(): BaseSeverity {
+    return when {
+        this == 0.0 -> BaseSeverity.NONE
+        this < 4.0 -> BaseSeverity.LOW
+        this < 7.0 -> BaseSeverity.MEDIUM
+        this < 9.0 -> BaseSeverity.HIGH
+        this <= 10.0 -> BaseSeverity.CRITICAL
+        else -> throw IllegalArgumentException("invalid score")
+    }
+}
+
+operator fun Double.minus(value: MetricValue<*>): Double {
+    return this - value.numericalValue
+}
+
+operator fun Double.times(value: MetricValue<*>): Double {
+    return this * value.numericalValue
+}
+
+operator fun MetricValue<*>.times(value: MetricValue<*>): Double {
+    return this.numericalValue * value.numericalValue
+}
+
+interface CvssCalculation {
+
+    val metrics: Map<String, String>
+
+    fun calculateBaseScore(): Double
+}

--- a/csaf-cvss/src/main/kotlin/io/github/csaf/sbom/cvss/Extensions.kt
+++ b/csaf-cvss/src/main/kotlin/io/github/csaf/sbom/cvss/Extensions.kt
@@ -47,3 +47,37 @@ interface CvssCalculation {
 
     fun calculateBaseScore(): Double
 }
+
+fun String.toCvssMetrics(allowedVersions: List<String>?): MutableMap<String, String> {
+    // Split the vector into parts
+    val parts = this.split("/")
+
+    // A map of metrics and their values.
+    val metrics = mutableMapOf<String, String>()
+
+    for ((idx, part) in parts.withIndex()) {
+        val keyValue = part.split(":")
+        val key = keyValue.first()
+        val value = keyValue.getOrNull(1)
+
+        if (allowedVersions != null) {
+            if (idx == 0 && (key != "CVSS" || (value !in allowedVersions))) {
+                // First key must be CVSS:3.X
+                throw IllegalArgumentException("Invalid CVSS format or version")
+            }
+        }
+
+        if (value == null) {
+            throw IllegalArgumentException("Value for $key is missing")
+        }
+
+        if (key in metrics) {
+            // Metric was already defined -> illegal
+            throw IllegalArgumentException("Metric $key already defined")
+        } else {
+            metrics[key] = value
+        }
+    }
+
+    return metrics
+}

--- a/csaf-cvss/src/main/kotlin/io/github/csaf/sbom/cvss/Extensions.kt
+++ b/csaf-cvss/src/main/kotlin/io/github/csaf/sbom/cvss/Extensions.kt
@@ -46,6 +46,10 @@ interface CvssCalculation {
     val metrics: Map<String, String>
 
     fun calculateBaseScore(): Double
+
+    fun calculateTemporalScore(): Double
+
+    fun calculateEnvironmentalScore(): Double
 }
 
 fun String.toCvssMetrics(allowedVersions: List<String>?): MutableMap<String, String> {

--- a/csaf-cvss/src/main/kotlin/io/github/csaf/sbom/cvss/Extensions.kt
+++ b/csaf-cvss/src/main/kotlin/io/github/csaf/sbom/cvss/Extensions.kt
@@ -41,6 +41,10 @@ operator fun MetricValue<*>.times(value: MetricValue<*>): Double {
     return this.numericalValue * value.numericalValue
 }
 
+/**
+ * Converts this vector string into a map of CVSS metrics. The [allowedVersions] list must be
+ * specified if the standard is 3.X.
+ */
 fun String.toCvssMetrics(allowedVersions: List<String>?): MutableMap<String, String> {
     // Split the vector into parts
     val parts = this.split("/")
@@ -53,6 +57,7 @@ fun String.toCvssMetrics(allowedVersions: List<String>?): MutableMap<String, Str
         val key = keyValue.first()
         val value = keyValue.getOrNull(1)
 
+        // Allowed versions are only applicable for CVSS 3.X
         if (allowedVersions != null) {
             if (idx == 0 && (key != "CVSS" || (value !in allowedVersions))) {
                 // First key must be CVSS:3.X

--- a/csaf-cvss/src/main/kotlin/io/github/csaf/sbom/cvss/Extensions.kt
+++ b/csaf-cvss/src/main/kotlin/io/github/csaf/sbom/cvss/Extensions.kt
@@ -41,17 +41,6 @@ operator fun MetricValue<*>.times(value: MetricValue<*>): Double {
     return this.numericalValue * value.numericalValue
 }
 
-interface CvssCalculation {
-
-    val metrics: Map<String, String>
-
-    fun calculateBaseScore(): Double
-
-    fun calculateTemporalScore(): Double
-
-    fun calculateEnvironmentalScore(): Double
-}
-
 fun String.toCvssMetrics(allowedVersions: List<String>?): MutableMap<String, String> {
     // Split the vector into parts
     val parts = this.split("/")

--- a/csaf-cvss/src/main/kotlin/io/github/csaf/sbom/cvss/MetricValue.kt
+++ b/csaf-cvss/src/main/kotlin/io/github/csaf/sbom/cvss/MetricValue.kt
@@ -22,12 +22,12 @@ import kotlin.reflect.KProperty
  * Represents the value of a CVSS metric. This class should not be used directly, instead metrics
  * should be defined by [requiredMetric] and [optionalMetric].
  */
-open class MetricValue<PropertyEnum : Enum<PropertyEnum>>(
+class MetricValue<PropertyEnum : Enum<PropertyEnum>>(
     /** The enum value of this metric, as defined in [PropertyEnum]. */
     val enumValue: PropertyEnum,
 
     /** The numeric value of this metric. */
-    open val numericalValue: Double,
+    val numericalValue: Double,
 )
 
 internal open class MetricDelegate<PropertyEnum : Enum<PropertyEnum>>(

--- a/csaf-cvss/src/main/kotlin/io/github/csaf/sbom/cvss/v2/Calculation.kt
+++ b/csaf-cvss/src/main/kotlin/io/github/csaf/sbom/cvss/v2/Calculation.kt
@@ -148,7 +148,7 @@ class CvssV2Calculation(override val metrics: Map<String, String>) : CvssCalcula
         )
     val integrityRequirement by
         optionalMetric(
-            "CR",
+            "IR",
             mapOf(
                 ConfidentialityRequirement.LOW to Pair("L", 0.5),
                 ConfidentialityRequirement.MEDIUM to Pair("M", 1.0),
@@ -158,7 +158,7 @@ class CvssV2Calculation(override val metrics: Map<String, String>) : CvssCalcula
         )
     val availabilityRequirement by
         optionalMetric(
-            "CR",
+            "AR",
             mapOf(
                 ConfidentialityRequirement.LOW to Pair("L", 0.5),
                 ConfidentialityRequirement.MEDIUM to Pair("M", 1.0),

--- a/csaf-cvss/src/main/kotlin/io/github/csaf/sbom/cvss/v2/Calculation.kt
+++ b/csaf-cvss/src/main/kotlin/io/github/csaf/sbom/cvss/v2/Calculation.kt
@@ -19,7 +19,6 @@ package io.github.csaf.sbom.cvss.v2
 import io.github.csaf.sbom.cvss.*
 import io.github.csaf.sbom.schema.generated.Csaf.*
 import kotlin.math.min
-import kotlin.math.pow
 import kotlin.math.round
 
 class CvssV2Calculation(override val metrics: Map<String, String>) : CvssCalculation {
@@ -169,12 +168,17 @@ class CvssV2Calculation(override val metrics: Map<String, String>) : CvssCalcula
         )
 
     // Calculated scores
-    val baseScore by lazy { calculateBaseScore() }
-    val baseSeverity = baseScore.toSeverity()
+    val baseScore = calculateBaseScore()
+    val baseSeverity
+        get() = baseScore.toSeverity()
+
     val temporalScore by lazy { calculateTemporalScore() }
-    val temporalSeverity = temporalScore.toSeverity()
+    val temporalSeverity
+        get() = temporalScore.toSeverity()
+
     val environmentalScore by lazy { calculateEnvironmentalScore() }
-    val environmentalSeverity = environmentalScore.toSeverity()
+    val environmentalSeverity
+        get() = environmentalScore.toSeverity()
 
     override fun calculateBaseScore(): Double {
         val impact =
@@ -222,10 +226,7 @@ class CvssV2Calculation(override val metrics: Map<String, String>) : CvssCalcula
         )
     }
 
-    fun roundTo1Decimal(x: Double): Double {
-        val factor = 10.0.pow(1)
-        return round(x * factor) / factor
-    }
+    fun roundTo1Decimal(x: Double): Double = round(x * 10.0) / 10.0
 
     companion object {
         fun fromVectorString(vec: String): CvssV2Calculation {

--- a/csaf-cvss/src/main/kotlin/io/github/csaf/sbom/cvss/v2/Calculation.kt
+++ b/csaf-cvss/src/main/kotlin/io/github/csaf/sbom/cvss/v2/Calculation.kt
@@ -169,16 +169,13 @@ class CvssV2Calculation(override val metrics: Map<String, String>) : CvssCalcula
 
     // Calculated scores
     val baseScore = calculateBaseScore()
-    val baseSeverity
-        get() = baseScore.toSeverity()
+    val baseSeverity = baseScore.toSeverity()
 
-    val temporalScore by lazy { calculateTemporalScore() }
-    val temporalSeverity
-        get() = temporalScore.toSeverity()
+    val temporalScore = calculateTemporalScore()
+    val temporalSeverity = temporalScore.toSeverity()
 
-    val environmentalScore by lazy { calculateEnvironmentalScore() }
-    val environmentalSeverity
-        get() = environmentalScore.toSeverity()
+    val environmentalScore = calculateEnvironmentalScore()
+    val environmentalSeverity = environmentalScore.toSeverity()
 
     override fun calculateBaseScore(): Double {
         val impact =

--- a/csaf-cvss/src/main/kotlin/io/github/csaf/sbom/cvss/v2/Calculation.kt
+++ b/csaf-cvss/src/main/kotlin/io/github/csaf/sbom/cvss/v2/Calculation.kt
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2024, The Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.github.csaf.sbom.cvss.v2
+
+import io.github.csaf.sbom.cvss.*
+import io.github.csaf.sbom.schema.generated.Csaf.*
+import kotlin.math.pow
+import kotlin.math.round
+
+class CvssV2Calculation(override val metrics: Map<String, String>) : CvssCalculation {
+    // Base
+    val accessVector by
+        requiredMetric(
+            "AV",
+            mapOf(
+                AccessVector.LOCAL to Pair("L", 0.395),
+                AccessVector.ADJACENT_NETWORK to Pair("A", 0.646),
+                AccessVector.NETWORK to Pair("N", 1.0),
+            )
+        )
+    val accessComplexity by
+        requiredMetric(
+            "AC",
+            mapOf(
+                AccessComplexity.HIGH to Pair("H", 0.35),
+                AccessComplexity.MEDIUM to Pair("M", 0.61),
+                AccessComplexity.LOW to Pair("L", 0.71),
+            )
+        )
+    val authentication by
+        requiredMetric(
+            "Au",
+            mapOf(
+                Authentication.MULTIPLE to Pair("M", 0.45),
+                Authentication.SINGLE to Pair("S", 0.56),
+                Authentication.NONE to Pair("N", 0.704),
+            )
+        )
+    val confidentialityImpact by
+        requiredMetric(
+            "C",
+            mapOf(
+                ConfidentialityImpact.NONE to Pair("N", 0.0),
+                ConfidentialityImpact.PARTIAL to Pair("P", 0.275),
+                ConfidentialityImpact.COMPLETE to Pair("C", 0.660),
+            )
+        )
+    val integrityImpact by
+        requiredMetric(
+            "I",
+            mapOf(
+                ConfidentialityImpact.NONE to Pair("N", 0.0),
+                ConfidentialityImpact.PARTIAL to Pair("P", 0.275),
+                ConfidentialityImpact.COMPLETE to Pair("C", 0.660),
+            )
+        )
+    val availabilityImpact by
+        requiredMetric(
+            "A",
+            mapOf(
+                ConfidentialityImpact.NONE to Pair("N", 0.0),
+                ConfidentialityImpact.PARTIAL to Pair("P", 0.275),
+                ConfidentialityImpact.COMPLETE to Pair("C", 0.660),
+            )
+        )
+
+    // Temporal
+    val exploitability by
+        optionalMetric(
+            "E",
+            mapOf(
+                Exploitability.UNPROVEN to Pair("U", 0.85),
+                Exploitability.PROOF_OF_CONCEPT to Pair("POC", 0.9),
+                Exploitability.FUNCTIONAL to Pair("F", 0.95),
+                Exploitability.HIGH to Pair("H", 1.0),
+                Exploitability.NOT_DEFINED to Pair("ND", 1.0),
+            )
+        )
+    val remediationLevel by
+        optionalMetric(
+            "RL",
+            mapOf(
+                RemediationLevel.OFFICIAL_FIX to Pair("OF", 0.87),
+                RemediationLevel.TEMPORARY_FIX to Pair("TF", 0.90),
+                RemediationLevel.WORKAROUND to Pair("W", 0.95),
+                RemediationLevel.UNAVAILABLE to Pair("U", 1.0),
+                RemediationLevel.NOT_DEFINED to Pair("ND", 1.0)
+            )
+        )
+    val reportConfidence by
+        optionalMetric(
+            "RC",
+            mapOf(
+                ReportConfidence.UNCONFIRMED to Pair("UC", 0.90),
+                ReportConfidence.UNCORROBORATED to Pair("UR", 0.95),
+                ReportConfidence.CONFIRMED to Pair("C", 1.0),
+                ReportConfidence.NOT_DEFINED to Pair("ND", 1.0)
+            )
+        )
+
+    // Environmental
+    val collateralDamagePotential by
+        optionalMetric(
+            "CDP",
+            mapOf(
+                CollateralDamagePotential.NONE to Pair("N", 0.0),
+                CollateralDamagePotential.LOW to Pair("L", 0.1),
+                CollateralDamagePotential.LOW_MEDIUM to Pair("LM", 0.3),
+                CollateralDamagePotential.MEDIUM_HIGH to Pair("MH", 0.4),
+                CollateralDamagePotential.HIGH to Pair("H", 0.5),
+                CollateralDamagePotential.NOT_DEFINED to Pair("ND", 0.0),
+            )
+        )
+    val targetDistribution by
+        optionalMetric(
+            "TD",
+            mapOf(
+                TargetDistribution.NONE to Pair("N", 0.0),
+                TargetDistribution.LOW to Pair("L", 0.25),
+                TargetDistribution.MEDIUM to Pair("M", 0.75),
+                TargetDistribution.HIGH to Pair("H", 1.0),
+                TargetDistribution.NOT_DEFINED to Pair("ND", 1.0),
+            )
+        )
+    val confidentialityRequirement by
+        optionalMetric(
+            "CR",
+            mapOf(
+                ConfidentialityRequirement.LOW to Pair("L", 0.5),
+                ConfidentialityRequirement.MEDIUM to Pair("M", 1.0),
+                ConfidentialityRequirement.HIGH to Pair("H", 1.51),
+                ConfidentialityRequirement.NOT_DEFINED to Pair("ND", 1.0),
+            )
+        )
+    val integrityRequirement by
+        optionalMetric(
+            "CR",
+            mapOf(
+                ConfidentialityRequirement.LOW to Pair("L", 0.5),
+                ConfidentialityRequirement.MEDIUM to Pair("M", 1.0),
+                ConfidentialityRequirement.HIGH to Pair("H", 1.51),
+                ConfidentialityRequirement.NOT_DEFINED to Pair("ND", 1.0),
+            )
+        )
+    val availabilityRequirement by
+        optionalMetric(
+            "CR",
+            mapOf(
+                ConfidentialityRequirement.LOW to Pair("L", 0.5),
+                ConfidentialityRequirement.MEDIUM to Pair("M", 1.0),
+                ConfidentialityRequirement.HIGH to Pair("H", 1.51),
+                ConfidentialityRequirement.NOT_DEFINED to Pair("ND", 1.0),
+            )
+        )
+
+    override fun calculateBaseScore(): Double {
+        val impact =
+            10.41 *
+                (1 -
+                    (1.0 - confidentialityImpact) *
+                        (1.0 - integrityImpact) *
+                        (1.0 - availabilityImpact))
+        val exploitability = 20.0 * accessVector * accessComplexity * authentication
+        val fImpact =
+            if (impact == 0.0) {
+                0.0
+            } else {
+                1.176
+            }
+        return roundTo1Decimal(((0.6 * impact) + (0.4 * exploitability) - 1.5) * fImpact)
+    }
+
+    fun roundTo1Decimal(x: Double): Double {
+        val factor = 10.0.pow(1)
+        return round(x * factor) / factor
+    }
+
+    companion object {
+        fun fromVectorString(vec: String): CvssV2Calculation {
+            return CvssV2Calculation(vec.toCvssMetrics(allowedVersions = null))
+        }
+    }
+}

--- a/csaf-cvss/src/main/kotlin/io/github/csaf/sbom/cvss/v3/Calculation.kt
+++ b/csaf-cvss/src/main/kotlin/io/github/csaf/sbom/cvss/v3/Calculation.kt
@@ -139,14 +139,14 @@ class CvssV3Calculation(
             )
         )
     val remediationLevel by
-        optionalMetric<RemediationLevel>(
+        optionalMetric(
             "RL",
             mapOf(
-                RemediationLevel.NOT_DEFINED to Pair("X", 1.0),
-                RemediationLevel.UNAVAILABLE to Pair("U", 1.0),
-                RemediationLevel.WORKAROUND to Pair("W", 0.97),
-                RemediationLevel.TEMPORARY_FIX to Pair("T", 0.96),
-                RemediationLevel.OFFICIAL_FIX to Pair("O", 0.95),
+                RemediationLevel1.NOT_DEFINED to Pair("X", 1.0),
+                RemediationLevel1.UNAVAILABLE to Pair("U", 1.0),
+                RemediationLevel1.WORKAROUND to Pair("W", 0.97),
+                RemediationLevel1.TEMPORARY_FIX to Pair("T", 0.96),
+                RemediationLevel1.OFFICIAL_FIX to Pair("O", 0.95),
             )
         )
     val reportConfidence by

--- a/csaf-cvss/src/main/kotlin/io/github/csaf/sbom/cvss/v3/Calculation.kt
+++ b/csaf-cvss/src/main/kotlin/io/github/csaf/sbom/cvss/v3/Calculation.kt
@@ -1,0 +1,487 @@
+/*
+ * Copyright (c) 2024, The Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.github.csaf.sbom.cvss.v3
+
+import io.github.csaf.sbom.cvss.CvssCalculation
+import io.github.csaf.sbom.cvss.minus
+import io.github.csaf.sbom.cvss.optionalMetric
+import io.github.csaf.sbom.cvss.requiredMetric
+import io.github.csaf.sbom.cvss.times
+import io.github.csaf.sbom.schema.generated.Csaf.*
+import kotlin.math.ceil
+import kotlin.math.floor
+import kotlin.math.min
+import kotlin.math.pow
+import kotlin.math.roundToInt
+
+class CvssV3Calculation(
+    override val metrics: Map<String, String>,
+) : CvssCalculation {
+    val version: String?
+        get() {
+            return metrics["CVSS"]
+        }
+
+    // Base
+    val scope by
+        requiredMetric(
+            "S",
+            mapOf(
+                io.github.csaf.sbom.schema.generated.Csaf.Scope.CHANGED to Pair("C", 1.0),
+                io.github.csaf.sbom.schema.generated.Csaf.Scope.UNCHANGED to Pair("U", 0.0),
+            )
+        )
+    val confidentialityImpact by
+        requiredMetric(
+            "C",
+            mapOf(
+                io.github.csaf.sbom.schema.generated.Csaf.ConfidentialityImpact1.HIGH to
+                    Pair("H", 0.56),
+                io.github.csaf.sbom.schema.generated.Csaf.ConfidentialityImpact1.LOW to
+                    Pair("L", 0.22),
+                io.github.csaf.sbom.schema.generated.Csaf.ConfidentialityImpact1.NONE to
+                    Pair("N", 0.00),
+            )
+        )
+    val integrityImpact by
+        requiredMetric(
+            "I",
+            mapOf(
+                io.github.csaf.sbom.schema.generated.Csaf.ConfidentialityImpact1.HIGH to
+                    Pair("H", 0.56),
+                io.github.csaf.sbom.schema.generated.Csaf.ConfidentialityImpact1.LOW to
+                    Pair("L", 0.22),
+                io.github.csaf.sbom.schema.generated.Csaf.ConfidentialityImpact1.NONE to
+                    Pair("N", 0.00),
+            )
+        )
+    val availabilityImpact by
+        requiredMetric(
+            "A",
+            mapOf(
+                io.github.csaf.sbom.schema.generated.Csaf.ConfidentialityImpact1.HIGH to
+                    Pair("H", 0.56),
+                io.github.csaf.sbom.schema.generated.Csaf.ConfidentialityImpact1.LOW to
+                    Pair("L", 0.22),
+                io.github.csaf.sbom.schema.generated.Csaf.ConfidentialityImpact1.NONE to
+                    Pair("N", 0.00),
+            )
+        )
+    val attackVector by
+        requiredMetric(
+            "AV",
+            mapOf(
+                io.github.csaf.sbom.schema.generated.Csaf.AttackVector.NETWORK to Pair("N", 0.85),
+                io.github.csaf.sbom.schema.generated.Csaf.AttackVector.ADJACENT_NETWORK to
+                    Pair("A", 0.62),
+                io.github.csaf.sbom.schema.generated.Csaf.AttackVector.LOCAL to Pair("L", 0.55),
+                io.github.csaf.sbom.schema.generated.Csaf.AttackVector.PHYSICAL to Pair("P", 0.20),
+            )
+        )
+    val attackComplexity by
+        requiredMetric<io.github.csaf.sbom.schema.generated.Csaf.AttackComplexity>(
+            "AC",
+            mapOf(
+                io.github.csaf.sbom.schema.generated.Csaf.AttackComplexity.LOW to Pair("L", 0.77),
+                io.github.csaf.sbom.schema.generated.Csaf.AttackComplexity.HIGH to Pair("H", 0.44),
+            )
+        )
+    val privilegesRequired by
+        requiredMetric<io.github.csaf.sbom.schema.generated.Csaf.PrivilegesRequired>(
+            "PR",
+            mapOf(
+                io.github.csaf.sbom.schema.generated.Csaf.PrivilegesRequired.NONE to
+                    Pair("N", 0.85),
+                io.github.csaf.sbom.schema.generated.Csaf.PrivilegesRequired.LOW to
+                    Pair(
+                        "L",
+                        if (scope.numericalValue == 1.0) {
+                            0.68
+                        } else {
+                            0.62
+                        }
+                    ),
+                io.github.csaf.sbom.schema.generated.Csaf.PrivilegesRequired.HIGH to
+                    Pair(
+                        "H",
+                        if (scope.numericalValue == 1.0) {
+                            0.50
+                        } else {
+                            0.27
+                        }
+                    ),
+            )
+        )
+    val userInteraction by
+        requiredMetric<io.github.csaf.sbom.schema.generated.Csaf.UserInteraction>(
+            "UI",
+            mapOf(
+                io.github.csaf.sbom.schema.generated.Csaf.UserInteraction.NONE to Pair("N", 0.85),
+                io.github.csaf.sbom.schema.generated.Csaf.UserInteraction.REQUIRED to
+                    Pair("R", 0.62),
+            )
+        )
+
+    // Temporal
+    val exploitCodeMaturity by
+        optionalMetric(
+            "E",
+            mapOf(
+                io.github.csaf.sbom.schema.generated.Csaf.ExploitCodeMaturity.NOT_DEFINED to
+                    Pair("X", 1.0),
+                io.github.csaf.sbom.schema.generated.Csaf.ExploitCodeMaturity.HIGH to
+                    Pair("H", 1.0),
+                io.github.csaf.sbom.schema.generated.Csaf.ExploitCodeMaturity.FUNCTIONAL to
+                    Pair("F", 0.97),
+                io.github.csaf.sbom.schema.generated.Csaf.ExploitCodeMaturity.PROOF_OF_CONCEPT to
+                    Pair("P", 0.94),
+                io.github.csaf.sbom.schema.generated.Csaf.ExploitCodeMaturity.UNPROVEN to
+                    Pair("U", 0.91),
+            )
+        )
+    val remediationLevel by
+        optionalMetric<io.github.csaf.sbom.schema.generated.Csaf.RemediationLevel>(
+            "RL",
+            mapOf(
+                io.github.csaf.sbom.schema.generated.Csaf.RemediationLevel.NOT_DEFINED to
+                    Pair("X", 1.0),
+                io.github.csaf.sbom.schema.generated.Csaf.RemediationLevel.UNAVAILABLE to
+                    Pair("U", 1.0),
+                io.github.csaf.sbom.schema.generated.Csaf.RemediationLevel.WORKAROUND to
+                    Pair("W", 0.97),
+                io.github.csaf.sbom.schema.generated.Csaf.RemediationLevel.TEMPORARY_FIX to
+                    Pair("T", 0.96),
+                io.github.csaf.sbom.schema.generated.Csaf.RemediationLevel.OFFICIAL_FIX to
+                    Pair("O", 0.95),
+            )
+        )
+    val reportConfidence by
+        optionalMetric(
+            "RC",
+            mapOf(
+                io.github.csaf.sbom.schema.generated.Csaf.ReportConfidence1.NOT_DEFINED to
+                    Pair("X", 1.0),
+                io.github.csaf.sbom.schema.generated.Csaf.ReportConfidence1.CONFIRMED to
+                    Pair("C", 1.0),
+                io.github.csaf.sbom.schema.generated.Csaf.ReportConfidence1.REASONABLE to
+                    Pair("R", 0.96),
+                io.github.csaf.sbom.schema.generated.Csaf.ReportConfidence1.UNKNOWN to
+                    Pair("U", 0.92)
+            )
+        )
+
+    // Environmental (additional properties)
+    val confidentialityRequirement by
+        optionalMetric(
+            "CR",
+            mapOf(
+                io.github.csaf.sbom.schema.generated.Csaf.ConfidentialityRequirement.NOT_DEFINED to
+                    Pair("X", 1.0),
+                io.github.csaf.sbom.schema.generated.Csaf.ConfidentialityRequirement.HIGH to
+                    Pair("H", 1.5),
+                io.github.csaf.sbom.schema.generated.Csaf.ConfidentialityRequirement.MEDIUM to
+                    Pair("M", 1.0),
+                io.github.csaf.sbom.schema.generated.Csaf.ConfidentialityRequirement.LOW to
+                    Pair("L", 0.5)
+            )
+        )
+    val integrityRequirement by
+        optionalMetric<io.github.csaf.sbom.schema.generated.Csaf.ConfidentialityRequirement>(
+            "IR",
+            mapOf(
+                io.github.csaf.sbom.schema.generated.Csaf.ConfidentialityRequirement.NOT_DEFINED to
+                    Pair("X", 1.0),
+                io.github.csaf.sbom.schema.generated.Csaf.ConfidentialityRequirement.HIGH to
+                    Pair("H", 1.5),
+                io.github.csaf.sbom.schema.generated.Csaf.ConfidentialityRequirement.MEDIUM to
+                    Pair("M", 1.0),
+                io.github.csaf.sbom.schema.generated.Csaf.ConfidentialityRequirement.LOW to
+                    Pair("L", 0.5)
+            )
+        )
+    val availabilityRequirement by
+        optionalMetric<io.github.csaf.sbom.schema.generated.Csaf.ConfidentialityRequirement>(
+            "AR",
+            mapOf(
+                io.github.csaf.sbom.schema.generated.Csaf.ConfidentialityRequirement.NOT_DEFINED to
+                    Pair("X", 1.0),
+                io.github.csaf.sbom.schema.generated.Csaf.ConfidentialityRequirement.HIGH to
+                    Pair("H", 1.5),
+                io.github.csaf.sbom.schema.generated.Csaf.ConfidentialityRequirement.MEDIUM to
+                    Pair("M", 1.0),
+                io.github.csaf.sbom.schema.generated.Csaf.ConfidentialityRequirement.LOW to
+                    Pair("L", 0.5)
+            )
+        )
+
+    // Environmental (modified, delegates)
+    val modifiedScope by
+        optionalMetric(
+            "MS",
+            mapOf(
+                io.github.csaf.sbom.schema.generated.Csaf.ModifiedScope.NOT_DEFINED to
+                    Pair("X", scope.numericalValue),
+                io.github.csaf.sbom.schema.generated.Csaf.ModifiedScope.CHANGED to Pair("C", 1.0),
+                io.github.csaf.sbom.schema.generated.Csaf.ModifiedScope.UNCHANGED to Pair("U", 0.0),
+            )
+        )
+    val modifiedAttackVector by
+        optionalMetric(
+            "MAV",
+            mapOf(
+                io.github.csaf.sbom.schema.generated.Csaf.ModifiedAttackVector.NOT_DEFINED to
+                    Pair("X", attackVector.numericalValue),
+                io.github.csaf.sbom.schema.generated.Csaf.ModifiedAttackVector.NETWORK to
+                    Pair("N", 0.85),
+                io.github.csaf.sbom.schema.generated.Csaf.ModifiedAttackVector.ADJACENT_NETWORK to
+                    Pair("A", 0.62),
+                io.github.csaf.sbom.schema.generated.Csaf.ModifiedAttackVector.LOCAL to
+                    Pair("L", 0.55),
+                io.github.csaf.sbom.schema.generated.Csaf.ModifiedAttackVector.PHYSICAL to
+                    Pair("P", 0.20),
+            )
+        )
+    val modifiedAttackComplexity by
+        optionalMetric(
+            "MAC",
+            mapOf(
+                io.github.csaf.sbom.schema.generated.Csaf.ModifiedAttackComplexity.NOT_DEFINED to
+                    Pair("X", attackComplexity.numericalValue),
+                io.github.csaf.sbom.schema.generated.Csaf.ModifiedAttackComplexity.LOW to
+                    Pair("L", 0.77),
+                io.github.csaf.sbom.schema.generated.Csaf.ModifiedAttackComplexity.HIGH to
+                    Pair("H", 0.44),
+            )
+        )
+    val modifiedPrivilegesRequired by
+        optionalMetric(
+            "MPR",
+            mapOf(
+                io.github.csaf.sbom.schema.generated.Csaf.ModifiedPrivilegesRequired.NOT_DEFINED to
+                    Pair("X", privilegesRequired.numericalValue),
+                io.github.csaf.sbom.schema.generated.Csaf.ModifiedPrivilegesRequired.NONE to
+                    Pair("N", 0.85),
+                io.github.csaf.sbom.schema.generated.Csaf.ModifiedPrivilegesRequired.LOW to
+                    Pair(
+                        "L",
+                        if (modifiedScope.numericalValue == 1.0) {
+                            0.68
+                        } else {
+                            0.62
+                        }
+                    ),
+                io.github.csaf.sbom.schema.generated.Csaf.ModifiedPrivilegesRequired.HIGH to
+                    Pair(
+                        "H",
+                        if (modifiedScope.numericalValue == 1.0) {
+                            0.50
+                        } else {
+                            0.27
+                        }
+                    ),
+            )
+        )
+    val modifiedUserInteraction by
+        optionalMetric(
+            "MUI",
+            mapOf(
+                io.github.csaf.sbom.schema.generated.Csaf.ModifiedUserInteraction.NOT_DEFINED to
+                    Pair("X", userInteraction.numericalValue),
+                io.github.csaf.sbom.schema.generated.Csaf.ModifiedUserInteraction.NONE to
+                    Pair("N", 0.85),
+                io.github.csaf.sbom.schema.generated.Csaf.ModifiedUserInteraction.REQUIRED to
+                    Pair("R", 0.62),
+            )
+        )
+    val modifiedConfidentialityImpact by
+        optionalMetric(
+            "MC",
+            mapOf(
+                io.github.csaf.sbom.schema.generated.Csaf.ModifiedConfidentialityImpact
+                    .NOT_DEFINED to Pair("X", confidentialityImpact.numericalValue),
+                io.github.csaf.sbom.schema.generated.Csaf.ModifiedConfidentialityImpact.HIGH to
+                    Pair("H", 0.56),
+                io.github.csaf.sbom.schema.generated.Csaf.ModifiedConfidentialityImpact.LOW to
+                    Pair("L", 0.22),
+                io.github.csaf.sbom.schema.generated.Csaf.ModifiedConfidentialityImpact.NONE to
+                    Pair("N", 0.00),
+            )
+        )
+    val modifiedIntegrityImpact by
+        optionalMetric(
+            "MI",
+            mapOf(
+                io.github.csaf.sbom.schema.generated.Csaf.ModifiedConfidentialityImpact
+                    .NOT_DEFINED to Pair("X", integrityImpact.numericalValue),
+                io.github.csaf.sbom.schema.generated.Csaf.ModifiedConfidentialityImpact.HIGH to
+                    Pair("H", 0.56),
+                io.github.csaf.sbom.schema.generated.Csaf.ModifiedConfidentialityImpact.LOW to
+                    Pair("L", 0.22),
+                io.github.csaf.sbom.schema.generated.Csaf.ModifiedConfidentialityImpact.NONE to
+                    Pair("N", 0.00),
+            )
+        )
+    val modifiedAvailabilityImpact by
+        optionalMetric(
+            "MA",
+            mapOf(
+                io.github.csaf.sbom.schema.generated.Csaf.ModifiedConfidentialityImpact
+                    .NOT_DEFINED to Pair("X", availabilityImpact.numericalValue),
+                io.github.csaf.sbom.schema.generated.Csaf.ModifiedConfidentialityImpact.HIGH to
+                    Pair("H", 0.56),
+                io.github.csaf.sbom.schema.generated.Csaf.ModifiedConfidentialityImpact.LOW to
+                    Pair("L", 0.22),
+                io.github.csaf.sbom.schema.generated.Csaf.ModifiedConfidentialityImpact.NONE to
+                    Pair("N", 0.00),
+            )
+        )
+
+    override fun calculateBaseScore(): Double {
+        val impact = calculateImpact()
+        val exploit = calculateExploitability()
+        return if (impact <= 0.0) {
+            0.0
+        } else if (scope.numericalValue == 0.0) {
+            roundUp(min(impact + exploit, 10.0))
+        } else {
+            roundUp(min(1.08 * (impact + exploit), 10.0))
+        }
+    }
+
+    companion object {
+        fun fromVectorString(vec: String): CvssV3Calculation {
+            // Split the vector into parts
+            val parts = vec.split("/")
+
+            // A map of metrics and their values.
+            val metrics = mutableMapOf<String, String>()
+
+            for ((idx, part) in parts.withIndex()) {
+                val keyValue = part.split(":")
+                val key = keyValue.first()
+                val value = keyValue.getOrNull(1)
+
+                if (idx == 0 && (key != "CVSS" || (value != "3.0" && value != "3.1"))) {
+                    // First key must be CVSS:3.X
+                    throw IllegalArgumentException("Invalid CVSS format or version")
+                }
+
+                if (value == null) {
+                    throw IllegalArgumentException("Value for $key is missing")
+                }
+
+                if (key in metrics) {
+                    // Metric was already defined -> illegal
+                    throw IllegalArgumentException("Metric $key already defined")
+                } else {
+                    metrics[key] = value
+                }
+            }
+
+            return CvssV3Calculation(metrics)
+        }
+    }
+}
+
+fun CvssV3Calculation.calculateModifiedImpact(): Double {
+    val iscModified =
+        min(
+            (1 -
+                (1 - modifiedConfidentialityImpact * confidentialityRequirement) *
+                    (1 - modifiedIntegrityImpact * integrityRequirement) *
+                    (1 - modifiedAvailabilityImpact * availabilityRequirement)),
+            0.915
+        )
+    return if (modifiedScope.numericalValue == 0.0) {
+        6.42 * iscModified
+    } else if (version == "3.1") {
+        7.52 * (iscModified - 0.029) - 3.25 * (iscModified * 0.9731 - 0.02).pow(13)
+    } else {
+        7.52 * (iscModified - 0.029) - 3.25 * (iscModified - 0.02).pow(15)
+    }
+}
+
+fun CvssV3Calculation.calculateModifiedExploitability(): Double {
+    return 8.22 *
+        modifiedAttackVector *
+        modifiedAttackComplexity *
+        modifiedPrivilegesRequired *
+        modifiedUserInteraction
+}
+
+fun CvssV3Calculation.calculateTemporalScore(): Double {
+    return roundUp(calculateBaseScore() * exploitCodeMaturity * remediationLevel * reportConfidence)
+}
+
+fun CvssV3Calculation.calculateEnvironmentalScore(): Double {
+    val impact = calculateModifiedImpact()
+    val exploitability = calculateModifiedExploitability()
+
+    return if (impact <= 0.0) {
+        0.0
+    } else if (modifiedScope.numericalValue == 0.0) {
+        roundUp(
+            roundUp(min((impact + exploitability), 10.0)) *
+                exploitCodeMaturity *
+                remediationLevel *
+                reportConfidence
+        )
+    } else {
+        roundUp(
+            roundUp(min(1.08 * (impact + exploitability), 10.0)) *
+                exploitCodeMaturity *
+                remediationLevel *
+                reportConfidence
+        )
+    }
+}
+
+fun CvssV3Calculation.calculateImpact(): Double {
+    val iscBase =
+        1.0 - ((1.0 - confidentialityImpact) * (1.0 - integrityImpact) * (1.0 - availabilityImpact))
+    return if (scope.numericalValue == 0.0) {
+        6.42 * iscBase
+    } else {
+        7.52 * (iscBase - 0.029) - 3.52 * (iscBase - 0.02).pow(15)
+    }
+}
+
+fun CvssV3Calculation.calculateExploitability(): Double {
+    return 8.22 * attackVector * attackComplexity * privilegesRequired * userInteraction
+}
+
+/**
+ * Implementation of the "round up" function used in the calculations. According to the
+ * specification, it should return "the smallest number, specified to 1 decimal place, that is equal
+ * to or higher than its input."
+ *
+ * For CVSS 3.1, it follows the implementation guidance in
+ * [Appendix A](https://www.first.org/cvss/v3.1/specification-document#Appendix-A---Floating-Point-Rounding).
+ */
+fun CvssV3Calculation.roundUp(x: Double): Double {
+    return if (version == "3.1") {
+        var intInput = (x * 100000).roundToInt()
+        if ((intInput % 10000) == 0) {
+            intInput / 100000.0
+        } else {
+            return (floor(intInput / 10000.0) + 1) / 10.0
+        }
+    } else {
+        val factor = 10.0.pow(1)
+        ceil(x * factor) / factor
+    }
+}

--- a/csaf-cvss/src/main/kotlin/io/github/csaf/sbom/cvss/v3/Calculation.kt
+++ b/csaf-cvss/src/main/kotlin/io/github/csaf/sbom/cvss/v3/Calculation.kt
@@ -21,6 +21,7 @@ import io.github.csaf.sbom.cvss.minus
 import io.github.csaf.sbom.cvss.optionalMetric
 import io.github.csaf.sbom.cvss.requiredMetric
 import io.github.csaf.sbom.cvss.times
+import io.github.csaf.sbom.cvss.toCvssMetrics
 import io.github.csaf.sbom.cvss.toSeverity
 import io.github.csaf.sbom.schema.generated.Csaf.*
 import kotlin.math.ceil
@@ -313,35 +314,7 @@ class CvssV3Calculation(
 
     companion object {
         fun fromVectorString(vec: String): CvssV3Calculation {
-            // Split the vector into parts
-            val parts = vec.split("/")
-
-            // A map of metrics and their values.
-            val metrics = mutableMapOf<String, String>()
-
-            for ((idx, part) in parts.withIndex()) {
-                val keyValue = part.split(":")
-                val key = keyValue.first()
-                val value = keyValue.getOrNull(1)
-
-                if (idx == 0 && (key != "CVSS" || (value != "3.0" && value != "3.1"))) {
-                    // First key must be CVSS:3.X
-                    throw IllegalArgumentException("Invalid CVSS format or version")
-                }
-
-                if (value == null) {
-                    throw IllegalArgumentException("Value for $key is missing")
-                }
-
-                if (key in metrics) {
-                    // Metric was already defined -> illegal
-                    throw IllegalArgumentException("Metric $key already defined")
-                } else {
-                    metrics[key] = value
-                }
-            }
-
-            return CvssV3Calculation(metrics)
+            return CvssV3Calculation(vec.toCvssMetrics(listOf("3.0", "3.1")))
         }
     }
 }

--- a/csaf-cvss/src/main/kotlin/io/github/csaf/sbom/cvss/v3/Calculation.kt
+++ b/csaf-cvss/src/main/kotlin/io/github/csaf/sbom/cvss/v3/Calculation.kt
@@ -293,12 +293,17 @@ class CvssV3Calculation(
         )
 
     // Calculated scores
-    val baseScore by lazy { calculateBaseScore() }
-    val baseSeverity = baseScore.toSeverity()
+    val baseScore = calculateBaseScore()
+    val baseSeverity
+        get() = baseScore.toSeverity()
+
     val temporalScore by lazy { calculateTemporalScore() }
-    val temporalSeverity = temporalScore.toSeverity()
+    val temporalSeverity
+        get() = temporalScore.toSeverity()
+
     val environmentalScore by lazy { calculateEnvironmentalScore() }
-    val environmentalSeverity = environmentalScore.toSeverity()
+    val environmentalSeverity
+        get() = environmentalScore.toSeverity()
 
     override fun calculateBaseScore(): Double {
         val impact = calculateImpact()
@@ -378,7 +383,7 @@ fun CvssV3Calculation.calculateImpact(): Double {
     return if (scope.numericalValue == 0.0) {
         6.42 * iscBase
     } else {
-        7.52 * (iscBase - 0.029) - 3.52 * (iscBase - 0.02).pow(15)
+        7.52 * (iscBase - 0.029) - 3.25 * (iscBase - 0.02).pow(15)
     }
 }
 
@@ -400,10 +405,9 @@ fun CvssV3Calculation.roundUp(x: Double): Double {
         if ((intInput % 10000) == 0) {
             intInput / 100000.0
         } else {
-            return (floor(intInput / 10000.0) + 1) / 10.0
+            (floor(intInput / 10000.0) + 1) / 10.0
         }
     } else {
-        val factor = 10.0.pow(1)
-        ceil(x * factor) / factor
+        ceil(x * 10.0) / 10.0
     }
 }

--- a/csaf-cvss/src/main/kotlin/io/github/csaf/sbom/cvss/v3/Calculation.kt
+++ b/csaf-cvss/src/main/kotlin/io/github/csaf/sbom/cvss/v3/Calculation.kt
@@ -302,16 +302,13 @@ class CvssV3Calculation(
 
     // Calculated scores
     val baseScore = calculateBaseScore()
-    val baseSeverity
-        get() = baseScore.toSeverity()
+    val baseSeverity = baseScore.toSeverity()
 
-    val temporalScore by lazy { calculateTemporalScore() }
-    val temporalSeverity
-        get() = temporalScore.toSeverity()
+    val temporalScore = calculateTemporalScore()
+    val temporalSeverity = temporalScore.toSeverity()
 
-    val environmentalScore by lazy { calculateEnvironmentalScore() }
-    val environmentalSeverity
-        get() = environmentalScore.toSeverity()
+    val environmentalScore = calculateEnvironmentalScore()
+    val environmentalSeverity = environmentalScore.toSeverity()
 
     override fun calculateBaseScore(): Double {
         val impact = calculateImpact()

--- a/csaf-cvss/src/main/kotlin/io/github/csaf/sbom/cvss/v3/Calculation.kt
+++ b/csaf-cvss/src/main/kotlin/io/github/csaf/sbom/cvss/v3/Calculation.kt
@@ -312,6 +312,33 @@ class CvssV3Calculation(
         }
     }
 
+    override fun calculateTemporalScore(): Double {
+        return roundUp(baseScore * exploitCodeMaturity * remediationLevel * reportConfidence)
+    }
+
+    override fun calculateEnvironmentalScore(): Double {
+        val impact = calculateModifiedImpact()
+        val exploitability = calculateModifiedExploitability()
+
+        return if (impact <= 0.0) {
+            0.0
+        } else if (modifiedScope.numericalValue == 0.0) {
+            roundUp(
+                roundUp(min((impact + exploitability), 10.0)) *
+                    exploitCodeMaturity *
+                    remediationLevel *
+                    reportConfidence
+            )
+        } else {
+            roundUp(
+                roundUp(min(1.08 * (impact + exploitability), 10.0)) *
+                    exploitCodeMaturity *
+                    remediationLevel *
+                    reportConfidence
+            )
+        }
+    }
+
     companion object {
         fun fromVectorString(vec: String): CvssV3Calculation {
             return CvssV3Calculation(vec.toCvssMetrics(listOf("3.0", "3.1")))
@@ -343,33 +370,6 @@ fun CvssV3Calculation.calculateModifiedExploitability(): Double {
         modifiedAttackComplexity *
         modifiedPrivilegesRequired *
         modifiedUserInteraction
-}
-
-fun CvssV3Calculation.calculateTemporalScore(): Double {
-    return roundUp(calculateBaseScore() * exploitCodeMaturity * remediationLevel * reportConfidence)
-}
-
-fun CvssV3Calculation.calculateEnvironmentalScore(): Double {
-    val impact = calculateModifiedImpact()
-    val exploitability = calculateModifiedExploitability()
-
-    return if (impact <= 0.0) {
-        0.0
-    } else if (modifiedScope.numericalValue == 0.0) {
-        roundUp(
-            roundUp(min((impact + exploitability), 10.0)) *
-                exploitCodeMaturity *
-                remediationLevel *
-                reportConfidence
-        )
-    } else {
-        roundUp(
-            roundUp(min(1.08 * (impact + exploitability), 10.0)) *
-                exploitCodeMaturity *
-                remediationLevel *
-                reportConfidence
-        )
-    }
 }
 
 fun CvssV3Calculation.calculateImpact(): Double {

--- a/csaf-cvss/src/main/kotlin/io/github/csaf/sbom/cvss/v3/Calculation.kt
+++ b/csaf-cvss/src/main/kotlin/io/github/csaf/sbom/cvss/v3/Calculation.kt
@@ -21,6 +21,7 @@ import io.github.csaf.sbom.cvss.minus
 import io.github.csaf.sbom.cvss.optionalMetric
 import io.github.csaf.sbom.cvss.requiredMetric
 import io.github.csaf.sbom.cvss.times
+import io.github.csaf.sbom.cvss.toSeverity
 import io.github.csaf.sbom.schema.generated.Csaf.*
 import kotlin.math.ceil
 import kotlin.math.floor
@@ -41,72 +42,61 @@ class CvssV3Calculation(
         requiredMetric(
             "S",
             mapOf(
-                io.github.csaf.sbom.schema.generated.Csaf.Scope.CHANGED to Pair("C", 1.0),
-                io.github.csaf.sbom.schema.generated.Csaf.Scope.UNCHANGED to Pair("U", 0.0),
+                Scope.CHANGED to Pair("C", 1.0),
+                Scope.UNCHANGED to Pair("U", 0.0),
             )
         )
     val confidentialityImpact by
         requiredMetric(
             "C",
             mapOf(
-                io.github.csaf.sbom.schema.generated.Csaf.ConfidentialityImpact1.HIGH to
-                    Pair("H", 0.56),
-                io.github.csaf.sbom.schema.generated.Csaf.ConfidentialityImpact1.LOW to
-                    Pair("L", 0.22),
-                io.github.csaf.sbom.schema.generated.Csaf.ConfidentialityImpact1.NONE to
-                    Pair("N", 0.00),
+                ConfidentialityImpact1.HIGH to Pair("H", 0.56),
+                ConfidentialityImpact1.LOW to Pair("L", 0.22),
+                ConfidentialityImpact1.NONE to Pair("N", 0.00),
             )
         )
     val integrityImpact by
         requiredMetric(
             "I",
             mapOf(
-                io.github.csaf.sbom.schema.generated.Csaf.ConfidentialityImpact1.HIGH to
-                    Pair("H", 0.56),
-                io.github.csaf.sbom.schema.generated.Csaf.ConfidentialityImpact1.LOW to
-                    Pair("L", 0.22),
-                io.github.csaf.sbom.schema.generated.Csaf.ConfidentialityImpact1.NONE to
-                    Pair("N", 0.00),
+                ConfidentialityImpact1.HIGH to Pair("H", 0.56),
+                ConfidentialityImpact1.LOW to Pair("L", 0.22),
+                ConfidentialityImpact1.NONE to Pair("N", 0.00),
             )
         )
     val availabilityImpact by
         requiredMetric(
             "A",
             mapOf(
-                io.github.csaf.sbom.schema.generated.Csaf.ConfidentialityImpact1.HIGH to
-                    Pair("H", 0.56),
-                io.github.csaf.sbom.schema.generated.Csaf.ConfidentialityImpact1.LOW to
-                    Pair("L", 0.22),
-                io.github.csaf.sbom.schema.generated.Csaf.ConfidentialityImpact1.NONE to
-                    Pair("N", 0.00),
+                ConfidentialityImpact1.HIGH to Pair("H", 0.56),
+                ConfidentialityImpact1.LOW to Pair("L", 0.22),
+                ConfidentialityImpact1.NONE to Pair("N", 0.00),
             )
         )
     val attackVector by
         requiredMetric(
             "AV",
             mapOf(
-                io.github.csaf.sbom.schema.generated.Csaf.AttackVector.NETWORK to Pair("N", 0.85),
-                io.github.csaf.sbom.schema.generated.Csaf.AttackVector.ADJACENT_NETWORK to
-                    Pair("A", 0.62),
-                io.github.csaf.sbom.schema.generated.Csaf.AttackVector.LOCAL to Pair("L", 0.55),
-                io.github.csaf.sbom.schema.generated.Csaf.AttackVector.PHYSICAL to Pair("P", 0.20),
+                AttackVector.NETWORK to Pair("N", 0.85),
+                AttackVector.ADJACENT_NETWORK to Pair("A", 0.62),
+                AttackVector.LOCAL to Pair("L", 0.55),
+                AttackVector.PHYSICAL to Pair("P", 0.20),
             )
         )
     val attackComplexity by
-        requiredMetric<io.github.csaf.sbom.schema.generated.Csaf.AttackComplexity>(
+        requiredMetric<AttackComplexity>(
             "AC",
             mapOf(
-                io.github.csaf.sbom.schema.generated.Csaf.AttackComplexity.LOW to Pair("L", 0.77),
-                io.github.csaf.sbom.schema.generated.Csaf.AttackComplexity.HIGH to Pair("H", 0.44),
+                AttackComplexity.LOW to Pair("L", 0.77),
+                AttackComplexity.HIGH to Pair("H", 0.44),
             )
         )
     val privilegesRequired by
-        requiredMetric<io.github.csaf.sbom.schema.generated.Csaf.PrivilegesRequired>(
+        requiredMetric<PrivilegesRequired>(
             "PR",
             mapOf(
-                io.github.csaf.sbom.schema.generated.Csaf.PrivilegesRequired.NONE to
-                    Pair("N", 0.85),
-                io.github.csaf.sbom.schema.generated.Csaf.PrivilegesRequired.LOW to
+                PrivilegesRequired.NONE to Pair("N", 0.85),
+                PrivilegesRequired.LOW to
                     Pair(
                         "L",
                         if (scope.numericalValue == 1.0) {
@@ -115,7 +105,7 @@ class CvssV3Calculation(
                             0.62
                         }
                     ),
-                io.github.csaf.sbom.schema.generated.Csaf.PrivilegesRequired.HIGH to
+                PrivilegesRequired.HIGH to
                     Pair(
                         "H",
                         if (scope.numericalValue == 1.0) {
@@ -127,12 +117,11 @@ class CvssV3Calculation(
             )
         )
     val userInteraction by
-        requiredMetric<io.github.csaf.sbom.schema.generated.Csaf.UserInteraction>(
+        requiredMetric<UserInteraction>(
             "UI",
             mapOf(
-                io.github.csaf.sbom.schema.generated.Csaf.UserInteraction.NONE to Pair("N", 0.85),
-                io.github.csaf.sbom.schema.generated.Csaf.UserInteraction.REQUIRED to
-                    Pair("R", 0.62),
+                UserInteraction.NONE to Pair("N", 0.85),
+                UserInteraction.REQUIRED to Pair("R", 0.62),
             )
         )
 
@@ -141,46 +130,32 @@ class CvssV3Calculation(
         optionalMetric(
             "E",
             mapOf(
-                io.github.csaf.sbom.schema.generated.Csaf.ExploitCodeMaturity.NOT_DEFINED to
-                    Pair("X", 1.0),
-                io.github.csaf.sbom.schema.generated.Csaf.ExploitCodeMaturity.HIGH to
-                    Pair("H", 1.0),
-                io.github.csaf.sbom.schema.generated.Csaf.ExploitCodeMaturity.FUNCTIONAL to
-                    Pair("F", 0.97),
-                io.github.csaf.sbom.schema.generated.Csaf.ExploitCodeMaturity.PROOF_OF_CONCEPT to
-                    Pair("P", 0.94),
-                io.github.csaf.sbom.schema.generated.Csaf.ExploitCodeMaturity.UNPROVEN to
-                    Pair("U", 0.91),
+                ExploitCodeMaturity.NOT_DEFINED to Pair("X", 1.0),
+                ExploitCodeMaturity.HIGH to Pair("H", 1.0),
+                ExploitCodeMaturity.FUNCTIONAL to Pair("F", 0.97),
+                ExploitCodeMaturity.PROOF_OF_CONCEPT to Pair("P", 0.94),
+                ExploitCodeMaturity.UNPROVEN to Pair("U", 0.91),
             )
         )
     val remediationLevel by
-        optionalMetric<io.github.csaf.sbom.schema.generated.Csaf.RemediationLevel>(
+        optionalMetric<RemediationLevel>(
             "RL",
             mapOf(
-                io.github.csaf.sbom.schema.generated.Csaf.RemediationLevel.NOT_DEFINED to
-                    Pair("X", 1.0),
-                io.github.csaf.sbom.schema.generated.Csaf.RemediationLevel.UNAVAILABLE to
-                    Pair("U", 1.0),
-                io.github.csaf.sbom.schema.generated.Csaf.RemediationLevel.WORKAROUND to
-                    Pair("W", 0.97),
-                io.github.csaf.sbom.schema.generated.Csaf.RemediationLevel.TEMPORARY_FIX to
-                    Pair("T", 0.96),
-                io.github.csaf.sbom.schema.generated.Csaf.RemediationLevel.OFFICIAL_FIX to
-                    Pair("O", 0.95),
+                RemediationLevel.NOT_DEFINED to Pair("X", 1.0),
+                RemediationLevel.UNAVAILABLE to Pair("U", 1.0),
+                RemediationLevel.WORKAROUND to Pair("W", 0.97),
+                RemediationLevel.TEMPORARY_FIX to Pair("T", 0.96),
+                RemediationLevel.OFFICIAL_FIX to Pair("O", 0.95),
             )
         )
     val reportConfidence by
         optionalMetric(
             "RC",
             mapOf(
-                io.github.csaf.sbom.schema.generated.Csaf.ReportConfidence1.NOT_DEFINED to
-                    Pair("X", 1.0),
-                io.github.csaf.sbom.schema.generated.Csaf.ReportConfidence1.CONFIRMED to
-                    Pair("C", 1.0),
-                io.github.csaf.sbom.schema.generated.Csaf.ReportConfidence1.REASONABLE to
-                    Pair("R", 0.96),
-                io.github.csaf.sbom.schema.generated.Csaf.ReportConfidence1.UNKNOWN to
-                    Pair("U", 0.92)
+                ReportConfidence1.NOT_DEFINED to Pair("X", 1.0),
+                ReportConfidence1.CONFIRMED to Pair("C", 1.0),
+                ReportConfidence1.REASONABLE to Pair("R", 0.96),
+                ReportConfidence1.UNKNOWN to Pair("U", 0.92)
             )
         )
 
@@ -189,42 +164,30 @@ class CvssV3Calculation(
         optionalMetric(
             "CR",
             mapOf(
-                io.github.csaf.sbom.schema.generated.Csaf.ConfidentialityRequirement.NOT_DEFINED to
-                    Pair("X", 1.0),
-                io.github.csaf.sbom.schema.generated.Csaf.ConfidentialityRequirement.HIGH to
-                    Pair("H", 1.5),
-                io.github.csaf.sbom.schema.generated.Csaf.ConfidentialityRequirement.MEDIUM to
-                    Pair("M", 1.0),
-                io.github.csaf.sbom.schema.generated.Csaf.ConfidentialityRequirement.LOW to
-                    Pair("L", 0.5)
+                ConfidentialityRequirement.NOT_DEFINED to Pair("X", 1.0),
+                ConfidentialityRequirement.HIGH to Pair("H", 1.5),
+                ConfidentialityRequirement.MEDIUM to Pair("M", 1.0),
+                ConfidentialityRequirement.LOW to Pair("L", 0.5)
             )
         )
     val integrityRequirement by
-        optionalMetric<io.github.csaf.sbom.schema.generated.Csaf.ConfidentialityRequirement>(
+        optionalMetric<ConfidentialityRequirement>(
             "IR",
             mapOf(
-                io.github.csaf.sbom.schema.generated.Csaf.ConfidentialityRequirement.NOT_DEFINED to
-                    Pair("X", 1.0),
-                io.github.csaf.sbom.schema.generated.Csaf.ConfidentialityRequirement.HIGH to
-                    Pair("H", 1.5),
-                io.github.csaf.sbom.schema.generated.Csaf.ConfidentialityRequirement.MEDIUM to
-                    Pair("M", 1.0),
-                io.github.csaf.sbom.schema.generated.Csaf.ConfidentialityRequirement.LOW to
-                    Pair("L", 0.5)
+                ConfidentialityRequirement.NOT_DEFINED to Pair("X", 1.0),
+                ConfidentialityRequirement.HIGH to Pair("H", 1.5),
+                ConfidentialityRequirement.MEDIUM to Pair("M", 1.0),
+                ConfidentialityRequirement.LOW to Pair("L", 0.5)
             )
         )
     val availabilityRequirement by
-        optionalMetric<io.github.csaf.sbom.schema.generated.Csaf.ConfidentialityRequirement>(
+        optionalMetric<ConfidentialityRequirement>(
             "AR",
             mapOf(
-                io.github.csaf.sbom.schema.generated.Csaf.ConfidentialityRequirement.NOT_DEFINED to
-                    Pair("X", 1.0),
-                io.github.csaf.sbom.schema.generated.Csaf.ConfidentialityRequirement.HIGH to
-                    Pair("H", 1.5),
-                io.github.csaf.sbom.schema.generated.Csaf.ConfidentialityRequirement.MEDIUM to
-                    Pair("M", 1.0),
-                io.github.csaf.sbom.schema.generated.Csaf.ConfidentialityRequirement.LOW to
-                    Pair("L", 0.5)
+                ConfidentialityRequirement.NOT_DEFINED to Pair("X", 1.0),
+                ConfidentialityRequirement.HIGH to Pair("H", 1.5),
+                ConfidentialityRequirement.MEDIUM to Pair("M", 1.0),
+                ConfidentialityRequirement.LOW to Pair("L", 0.5)
             )
         )
 
@@ -233,49 +196,39 @@ class CvssV3Calculation(
         optionalMetric(
             "MS",
             mapOf(
-                io.github.csaf.sbom.schema.generated.Csaf.ModifiedScope.NOT_DEFINED to
-                    Pair("X", scope.numericalValue),
-                io.github.csaf.sbom.schema.generated.Csaf.ModifiedScope.CHANGED to Pair("C", 1.0),
-                io.github.csaf.sbom.schema.generated.Csaf.ModifiedScope.UNCHANGED to Pair("U", 0.0),
+                ModifiedScope.NOT_DEFINED to Pair("X", scope.numericalValue),
+                ModifiedScope.CHANGED to Pair("C", 1.0),
+                ModifiedScope.UNCHANGED to Pair("U", 0.0),
             )
         )
     val modifiedAttackVector by
         optionalMetric(
             "MAV",
             mapOf(
-                io.github.csaf.sbom.schema.generated.Csaf.ModifiedAttackVector.NOT_DEFINED to
-                    Pair("X", attackVector.numericalValue),
-                io.github.csaf.sbom.schema.generated.Csaf.ModifiedAttackVector.NETWORK to
-                    Pair("N", 0.85),
-                io.github.csaf.sbom.schema.generated.Csaf.ModifiedAttackVector.ADJACENT_NETWORK to
-                    Pair("A", 0.62),
-                io.github.csaf.sbom.schema.generated.Csaf.ModifiedAttackVector.LOCAL to
-                    Pair("L", 0.55),
-                io.github.csaf.sbom.schema.generated.Csaf.ModifiedAttackVector.PHYSICAL to
-                    Pair("P", 0.20),
+                ModifiedAttackVector.NOT_DEFINED to Pair("X", attackVector.numericalValue),
+                ModifiedAttackVector.NETWORK to Pair("N", 0.85),
+                ModifiedAttackVector.ADJACENT_NETWORK to Pair("A", 0.62),
+                ModifiedAttackVector.LOCAL to Pair("L", 0.55),
+                ModifiedAttackVector.PHYSICAL to Pair("P", 0.20),
             )
         )
     val modifiedAttackComplexity by
         optionalMetric(
             "MAC",
             mapOf(
-                io.github.csaf.sbom.schema.generated.Csaf.ModifiedAttackComplexity.NOT_DEFINED to
-                    Pair("X", attackComplexity.numericalValue),
-                io.github.csaf.sbom.schema.generated.Csaf.ModifiedAttackComplexity.LOW to
-                    Pair("L", 0.77),
-                io.github.csaf.sbom.schema.generated.Csaf.ModifiedAttackComplexity.HIGH to
-                    Pair("H", 0.44),
+                ModifiedAttackComplexity.NOT_DEFINED to Pair("X", attackComplexity.numericalValue),
+                ModifiedAttackComplexity.LOW to Pair("L", 0.77),
+                ModifiedAttackComplexity.HIGH to Pair("H", 0.44),
             )
         )
     val modifiedPrivilegesRequired by
         optionalMetric(
             "MPR",
             mapOf(
-                io.github.csaf.sbom.schema.generated.Csaf.ModifiedPrivilegesRequired.NOT_DEFINED to
+                ModifiedPrivilegesRequired.NOT_DEFINED to
                     Pair("X", privilegesRequired.numericalValue),
-                io.github.csaf.sbom.schema.generated.Csaf.ModifiedPrivilegesRequired.NONE to
-                    Pair("N", 0.85),
-                io.github.csaf.sbom.schema.generated.Csaf.ModifiedPrivilegesRequired.LOW to
+                ModifiedPrivilegesRequired.NONE to Pair("N", 0.85),
+                ModifiedPrivilegesRequired.LOW to
                     Pair(
                         "L",
                         if (modifiedScope.numericalValue == 1.0) {
@@ -284,7 +237,7 @@ class CvssV3Calculation(
                             0.62
                         }
                     ),
-                io.github.csaf.sbom.schema.generated.Csaf.ModifiedPrivilegesRequired.HIGH to
+                ModifiedPrivilegesRequired.HIGH to
                     Pair(
                         "H",
                         if (modifiedScope.numericalValue == 1.0) {
@@ -299,56 +252,52 @@ class CvssV3Calculation(
         optionalMetric(
             "MUI",
             mapOf(
-                io.github.csaf.sbom.schema.generated.Csaf.ModifiedUserInteraction.NOT_DEFINED to
-                    Pair("X", userInteraction.numericalValue),
-                io.github.csaf.sbom.schema.generated.Csaf.ModifiedUserInteraction.NONE to
-                    Pair("N", 0.85),
-                io.github.csaf.sbom.schema.generated.Csaf.ModifiedUserInteraction.REQUIRED to
-                    Pair("R", 0.62),
+                ModifiedUserInteraction.NOT_DEFINED to Pair("X", userInteraction.numericalValue),
+                ModifiedUserInteraction.NONE to Pair("N", 0.85),
+                ModifiedUserInteraction.REQUIRED to Pair("R", 0.62),
             )
         )
     val modifiedConfidentialityImpact by
         optionalMetric(
             "MC",
             mapOf(
-                io.github.csaf.sbom.schema.generated.Csaf.ModifiedConfidentialityImpact
-                    .NOT_DEFINED to Pair("X", confidentialityImpact.numericalValue),
-                io.github.csaf.sbom.schema.generated.Csaf.ModifiedConfidentialityImpact.HIGH to
-                    Pair("H", 0.56),
-                io.github.csaf.sbom.schema.generated.Csaf.ModifiedConfidentialityImpact.LOW to
-                    Pair("L", 0.22),
-                io.github.csaf.sbom.schema.generated.Csaf.ModifiedConfidentialityImpact.NONE to
-                    Pair("N", 0.00),
+                ModifiedConfidentialityImpact.NOT_DEFINED to
+                    Pair("X", confidentialityImpact.numericalValue),
+                ModifiedConfidentialityImpact.HIGH to Pair("H", 0.56),
+                ModifiedConfidentialityImpact.LOW to Pair("L", 0.22),
+                ModifiedConfidentialityImpact.NONE to Pair("N", 0.00),
             )
         )
     val modifiedIntegrityImpact by
         optionalMetric(
             "MI",
             mapOf(
-                io.github.csaf.sbom.schema.generated.Csaf.ModifiedConfidentialityImpact
-                    .NOT_DEFINED to Pair("X", integrityImpact.numericalValue),
-                io.github.csaf.sbom.schema.generated.Csaf.ModifiedConfidentialityImpact.HIGH to
-                    Pair("H", 0.56),
-                io.github.csaf.sbom.schema.generated.Csaf.ModifiedConfidentialityImpact.LOW to
-                    Pair("L", 0.22),
-                io.github.csaf.sbom.schema.generated.Csaf.ModifiedConfidentialityImpact.NONE to
-                    Pair("N", 0.00),
+                ModifiedConfidentialityImpact.NOT_DEFINED to
+                    Pair("X", integrityImpact.numericalValue),
+                ModifiedConfidentialityImpact.HIGH to Pair("H", 0.56),
+                ModifiedConfidentialityImpact.LOW to Pair("L", 0.22),
+                ModifiedConfidentialityImpact.NONE to Pair("N", 0.00),
             )
         )
     val modifiedAvailabilityImpact by
         optionalMetric(
             "MA",
             mapOf(
-                io.github.csaf.sbom.schema.generated.Csaf.ModifiedConfidentialityImpact
-                    .NOT_DEFINED to Pair("X", availabilityImpact.numericalValue),
-                io.github.csaf.sbom.schema.generated.Csaf.ModifiedConfidentialityImpact.HIGH to
-                    Pair("H", 0.56),
-                io.github.csaf.sbom.schema.generated.Csaf.ModifiedConfidentialityImpact.LOW to
-                    Pair("L", 0.22),
-                io.github.csaf.sbom.schema.generated.Csaf.ModifiedConfidentialityImpact.NONE to
-                    Pair("N", 0.00),
+                ModifiedConfidentialityImpact.NOT_DEFINED to
+                    Pair("X", availabilityImpact.numericalValue),
+                ModifiedConfidentialityImpact.HIGH to Pair("H", 0.56),
+                ModifiedConfidentialityImpact.LOW to Pair("L", 0.22),
+                ModifiedConfidentialityImpact.NONE to Pair("N", 0.00),
             )
         )
+
+    // Calculated scores
+    val baseScore by lazy { calculateBaseScore() }
+    val baseSeverity = baseScore.toSeverity()
+    val temporalScore by lazy { calculateTemporalScore() }
+    val temporalSeverity = temporalScore.toSeverity()
+    val environmentalScore by lazy { calculateEnvironmentalScore() }
+    val environmentalSeverity = environmentalScore.toSeverity()
 
     override fun calculateBaseScore(): Double {
         val impact = calculateImpact()

--- a/csaf-cvss/src/test/kotlin/io/github/csaf/sbom/cvss/ExtensionTest.kt
+++ b/csaf-cvss/src/test/kotlin/io/github/csaf/sbom/cvss/ExtensionTest.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2024, The Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.github.csaf.sbom.cvss
+
+import io.github.csaf.sbom.schema.generated.Csaf
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class ExtensionTest {
+    @Test
+    fun testSeverity() {
+        assertEquals(
+            io.github.csaf.sbom.schema.generated.Csaf.BaseSeverity.CRITICAL,
+            10.0.toSeverity()
+        )
+        assertEquals(io.github.csaf.sbom.schema.generated.Csaf.BaseSeverity.HIGH, 7.2.toSeverity())
+        assertEquals(
+            io.github.csaf.sbom.schema.generated.Csaf.BaseSeverity.MEDIUM,
+            5.1.toSeverity()
+        )
+        assertEquals(io.github.csaf.sbom.schema.generated.Csaf.BaseSeverity.LOW, 0.4.toSeverity())
+        assertEquals(io.github.csaf.sbom.schema.generated.Csaf.BaseSeverity.NONE, 0.0.toSeverity())
+        assertFailsWith<IllegalArgumentException>() { 20.0.toSeverity() }
+    }
+}

--- a/csaf-cvss/src/test/kotlin/io/github/csaf/sbom/cvss/v2/CalculationTest.kt
+++ b/csaf-cvss/src/test/kotlin/io/github/csaf/sbom/cvss/v2/CalculationTest.kt
@@ -38,21 +38,24 @@ class CalculationTest {
 
     @Test
     fun testCalculateBaseScore() {
+        // Helper function to reduce redundancy
+        fun assertBaseScore(vector: String, expectedScore: Double) {
+            val calculation = CvssV2Calculation.fromVectorString(vector)
+            val score = calculation.calculateBaseScore()
+            assertEquals(expectedScore, score)
+        }
+
         // https://nvd.nist.gov/vuln-metrics/cvss/v2-calculator?vector=(AV:N/AC:M/Au:N/C:C/I:C/A:N/E:POC/RL:W/RC:C/CDP:N/TD:M/CR:ND/IR:ND/AR:ND)
-        var calc =
-            CvssV2Calculation.fromVectorString(
-                "AV:N/AC:M/Au:N/C:C/I:C/A:N/E:POC/RL:W/RC:C/CDP:N/TD:M/CR:ND/IR:ND/AR:ND"
-            )
-        var score = calc.calculateBaseScore()
-        assertEquals(8.8, score)
+        assertBaseScore(
+            "AV:N/AC:M/Au:N/C:C/I:C/A:N/E:POC/RL:W/RC:C/CDP:N/TD:M/CR:ND/IR:ND/AR:ND",
+            8.8
+        )
 
         // https://nvd.nist.gov/vuln-metrics/cvss/v2-calculator?vector=(AV:N/AC:M/Au:N/C:N/I:N/A:N/E:POC/RL:W/RC:C/CDP:N/TD:M/CR:ND/IR:ND/AR:ND)
-        calc =
-            CvssV2Calculation.fromVectorString(
-                "AV:N/AC:M/Au:N/C:N/I:N/A:N/E:POC/RL:W/RC:C/CDP:N/TD:M/CR:ND/IR:ND/AR:ND"
-            )
-        score = calc.calculateBaseScore()
-        assertEquals(0.0, score)
+        assertBaseScore(
+            "AV:N/AC:M/Au:N/C:N/I:N/A:N/E:POC/RL:W/RC:C/CDP:N/TD:M/CR:ND/IR:ND/AR:ND",
+            0.0
+        )
     }
 
     @Test

--- a/csaf-cvss/src/test/kotlin/io/github/csaf/sbom/cvss/v2/CalculationTest.kt
+++ b/csaf-cvss/src/test/kotlin/io/github/csaf/sbom/cvss/v2/CalculationTest.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2024, The Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.github.csaf.sbom.cvss.v2
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CalculationTest {
+    @Test
+    fun testCalculateBaseScore() {
+        // https://nvd.nist.gov/vuln-metrics/cvss/v2-calculator?vector=(AV:N/AC:M/Au:N/C:C/I:C/A:N/E:POC/RL:W/RC:C/CDP:N/TD:M/CR:ND/IR:ND/AR:ND)
+        val calc =
+            CvssV2Calculation.fromVectorString(
+                "AV:N/AC:M/Au:N/C:C/I:C/A:N/E:POC/RL:W/RC:C/CDP:N/TD:M/CR:ND/IR:ND/AR:ND"
+            )
+        val score = calc.calculateBaseScore()
+        assertEquals(8.8, score)
+    }
+}

--- a/csaf-cvss/src/test/kotlin/io/github/csaf/sbom/cvss/v2/CalculationTest.kt
+++ b/csaf-cvss/src/test/kotlin/io/github/csaf/sbom/cvss/v2/CalculationTest.kt
@@ -16,18 +16,64 @@
  */
 package io.github.csaf.sbom.cvss.v2
 
+import io.github.csaf.sbom.schema.generated.Csaf
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class CalculationTest {
     @Test
-    fun testCalculateBaseScore() {
+    fun testFromVectorString() {
         // https://nvd.nist.gov/vuln-metrics/cvss/v2-calculator?vector=(AV:N/AC:M/Au:N/C:C/I:C/A:N/E:POC/RL:W/RC:C/CDP:N/TD:M/CR:ND/IR:ND/AR:ND)
         val calc =
             CvssV2Calculation.fromVectorString(
                 "AV:N/AC:M/Au:N/C:C/I:C/A:N/E:POC/RL:W/RC:C/CDP:N/TD:M/CR:ND/IR:ND/AR:ND"
             )
-        val score = calc.calculateBaseScore()
+        assertEquals(8.8, calc.baseScore)
+        assertEquals(Csaf.BaseSeverity.HIGH, calc.baseSeverity)
+        assertEquals(7.5, calc.temporalScore)
+        assertEquals(Csaf.BaseSeverity.HIGH, calc.temporalSeverity)
+        assertEquals(5.6, calc.environmentalScore)
+        assertEquals(Csaf.BaseSeverity.MEDIUM, calc.environmentalSeverity)
+    }
+
+    @Test
+    fun testCalculateBaseScore() {
+        // https://nvd.nist.gov/vuln-metrics/cvss/v2-calculator?vector=(AV:N/AC:M/Au:N/C:C/I:C/A:N/E:POC/RL:W/RC:C/CDP:N/TD:M/CR:ND/IR:ND/AR:ND)
+        var calc =
+            CvssV2Calculation.fromVectorString(
+                "AV:N/AC:M/Au:N/C:C/I:C/A:N/E:POC/RL:W/RC:C/CDP:N/TD:M/CR:ND/IR:ND/AR:ND"
+            )
+        var score = calc.calculateBaseScore()
         assertEquals(8.8, score)
+
+        // https://nvd.nist.gov/vuln-metrics/cvss/v2-calculator?vector=(AV:N/AC:M/Au:N/C:N/I:N/A:N/E:POC/RL:W/RC:C/CDP:N/TD:M/CR:ND/IR:ND/AR:ND)
+        calc =
+            CvssV2Calculation.fromVectorString(
+                "AV:N/AC:M/Au:N/C:N/I:N/A:N/E:POC/RL:W/RC:C/CDP:N/TD:M/CR:ND/IR:ND/AR:ND"
+            )
+        score = calc.calculateBaseScore()
+        assertEquals(0.0, score)
+    }
+
+    @Test
+    fun testCalculateTemporalScore() {
+        // https://nvd.nist.gov/vuln-metrics/cvss/v2-calculator?vector=(AV:N/AC:M/Au:N/C:C/I:C/A:N/E:POC/RL:W/RC:C/CDP:N/TD:M/CR:ND/IR:ND/AR:ND)
+        val calc =
+            CvssV2Calculation.fromVectorString(
+                "AV:N/AC:M/Au:N/C:C/I:C/A:N/E:POC/RL:W/RC:C/CDP:N/TD:M/CR:ND/IR:ND/AR:ND"
+            )
+        val score = calc.calculateTemporalScore()
+        assertEquals(7.5, score)
+    }
+
+    @Test
+    fun testCalculateEnvironmentalScore() {
+        // https://nvd.nist.gov/vuln-metrics/cvss/v2-calculator?vector=(AV:N/AC:M/Au:N/C:C/I:C/A:N/E:POC/RL:W/RC:C/CDP:N/TD:M/CR:ND/IR:ND/AR:ND)
+        val calc =
+            CvssV2Calculation.fromVectorString(
+                "AV:N/AC:M/Au:N/C:C/I:C/A:N/E:POC/RL:W/RC:C/CDP:N/TD:M/CR:ND/IR:ND/AR:ND"
+            )
+        val score = calc.calculateEnvironmentalScore()
+        assertEquals(5.6, score)
     }
 }

--- a/csaf-cvss/src/test/kotlin/io/github/csaf/sbom/cvss/v3/CalculationTest.kt
+++ b/csaf-cvss/src/test/kotlin/io/github/csaf/sbom/cvss/v3/CalculationTest.kt
@@ -88,7 +88,7 @@ class CalculationTest {
                     )
             )
         var score = metrics.baseScore
-        assertEquals(Csaf.BaseSeverity.HIGH, metrics.baseSeverity)
+        assertEquals(Csaf.BaseSeverity.MEDIUM, metrics.baseSeverity)
         assertEquals(6.1, score)
 
         metrics =
@@ -116,7 +116,7 @@ class CalculationTest {
         // https://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
         metrics = CvssV3Calculation.fromVectorString("CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N")
         assertEquals(0.0, metrics.baseScore)
-        assertEquals(Csaf.BaseSeverity.LOW, metrics.baseSeverity)
+        assertEquals(Csaf.BaseSeverity.NONE, metrics.baseSeverity)
 
         // https://www.first.org/cvss/calculator/3.1#CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N/RL:W
         metrics =
@@ -134,7 +134,7 @@ class CalculationTest {
             )
         var score = metrics.calculateTemporalScore()
         assertEquals(4.7, score)
-        assertEquals(Csaf.BaseSeverity.LOW, metrics.temporalSeverity)
+        assertEquals(Csaf.BaseSeverity.MEDIUM, metrics.temporalSeverity)
 
         // https://www.first.org/cvss/calculator/3.1#CVSS:3.1/AV:P/AC:H/PR:L/UI:R/S:U/C:L/I:L/A:H/E:H/RL:U/RC:U
         metrics =
@@ -142,7 +142,7 @@ class CalculationTest {
                 "CVSS:3.1/AV:P/AC:H/PR:L/UI:R/S:U/C:L/I:L/A:H/E:H/RL:U/RC:U"
             )
         assertEquals(4.6, metrics.temporalScore)
-        assertEquals(Csaf.BaseSeverity.LOW, metrics.temporalSeverity)
+        assertEquals(Csaf.BaseSeverity.MEDIUM, metrics.temporalSeverity)
     }
 
     @Test
@@ -151,7 +151,7 @@ class CalculationTest {
         var metrics =
             CvssV3Calculation.fromVectorString("CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N")
         assertEquals(0.0, metrics.environmentalScore)
-        assertEquals(Csaf.BaseSeverity.LOW, metrics.environmentalSeverity)
+        assertEquals(Csaf.BaseSeverity.NONE, metrics.environmentalSeverity)
 
         // https://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
         metrics = CvssV3Calculation.fromVectorString("CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N")

--- a/csaf-cvss/src/test/kotlin/io/github/csaf/sbom/cvss/v3/CalculationTest.kt
+++ b/csaf-cvss/src/test/kotlin/io/github/csaf/sbom/cvss/v3/CalculationTest.kt
@@ -54,6 +54,20 @@ class CalculationTest {
             }
         assertNotNull(ex)
         assertEquals("Metric AC already defined", ex.message)
+
+        ex =
+            assertFailsWith<IllegalArgumentException> {
+                CvssV3Calculation.fromVectorString("CVSS:3.0/AC:H")
+            }
+        assertNotNull(ex)
+        assertEquals("Required property not present: scope", ex.message)
+
+        ex =
+            assertFailsWith<IllegalArgumentException> {
+                CvssV3Calculation.fromVectorString("CVSS:3.0/AV:N/AC:X/PR:L/UI:N/S:C/C:L/I:L/A:L")
+            }
+        assertNotNull(ex)
+        assertEquals("Invalid value: X in attackComplexity", ex.message)
     }
 
     @Test

--- a/csaf-cvss/src/test/kotlin/io/github/csaf/sbom/cvss/v3/CalculationTest.kt
+++ b/csaf-cvss/src/test/kotlin/io/github/csaf/sbom/cvss/v3/CalculationTest.kt
@@ -16,6 +16,7 @@
  */
 package io.github.csaf.sbom.cvss.v3
 
+import io.github.csaf.sbom.schema.generated.Csaf
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -86,7 +87,8 @@ class CalculationTest {
                         "UI" to "R",
                     )
             )
-        var score = metrics.calculateBaseScore()
+        var score = metrics.baseScore
+        assertEquals(Csaf.BaseSeverity.HIGH, metrics.baseSeverity)
         assertEquals(6.1, score)
 
         metrics =
@@ -103,24 +105,24 @@ class CalculationTest {
                         "UI" to "R",
                     )
             )
-        score = metrics.calculateBaseScore()
-        assertEquals(3.1, score)
+        assertEquals(3.1, metrics.baseScore)
+        assertEquals(Csaf.BaseSeverity.LOW, metrics.baseSeverity)
 
         // https://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:C/C:L/I:L/A:L
         metrics = CvssV3Calculation.fromVectorString("CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:C/C:L/I:L/A:L")
-        score = metrics.calculateBaseScore()
-        assertEquals(7.4, score)
+        assertEquals(7.4, metrics.baseScore)
+        assertEquals(Csaf.BaseSeverity.HIGH, metrics.baseSeverity)
 
         // https://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
         metrics = CvssV3Calculation.fromVectorString("CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N")
-        score = metrics.calculateBaseScore()
-        assertEquals(0.0, score)
+        assertEquals(0.0, metrics.baseScore)
+        assertEquals(Csaf.BaseSeverity.LOW, metrics.baseSeverity)
 
         // https://www.first.org/cvss/calculator/3.1#CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N/RL:W
         metrics =
             CvssV3Calculation.fromVectorString("CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N/RL:W")
-        score = metrics.calculateBaseScore()
-        assertEquals(6.1, score)
+        assertEquals(6.1, metrics.baseScore)
+        assertEquals(Csaf.BaseSeverity.MEDIUM, metrics.baseSeverity)
     }
 
     @Test
@@ -132,14 +134,15 @@ class CalculationTest {
             )
         var score = metrics.calculateTemporalScore()
         assertEquals(4.7, score)
+        assertEquals(Csaf.BaseSeverity.LOW, metrics.temporalSeverity)
 
         // https://www.first.org/cvss/calculator/3.1#CVSS:3.1/AV:P/AC:H/PR:L/UI:R/S:U/C:L/I:L/A:H/E:H/RL:U/RC:U
         metrics =
             CvssV3Calculation.fromVectorString(
                 "CVSS:3.1/AV:P/AC:H/PR:L/UI:R/S:U/C:L/I:L/A:H/E:H/RL:U/RC:U"
             )
-        score = metrics.calculateTemporalScore()
-        assertEquals(4.6, score)
+        assertEquals(4.6, metrics.temporalScore)
+        assertEquals(Csaf.BaseSeverity.LOW, metrics.temporalSeverity)
     }
 
     @Test
@@ -147,28 +150,28 @@ class CalculationTest {
         // https://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
         var metrics =
             CvssV3Calculation.fromVectorString("CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N")
-        var score = metrics.calculateEnvironmentalScore()
-        assertEquals(0.0, score)
+        assertEquals(0.0, metrics.environmentalScore)
+        assertEquals(Csaf.BaseSeverity.LOW, metrics.environmentalSeverity)
 
         // https://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
         metrics = CvssV3Calculation.fromVectorString("CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N")
-        score = metrics.calculateEnvironmentalScore()
-        assertEquals(7.5, score)
+        assertEquals(7.5, metrics.environmentalScore)
+        assertEquals(Csaf.BaseSeverity.HIGH, metrics.environmentalSeverity)
 
         // https://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H/E:U/RL:T/RC:U/CR:L/IR:L/AR:H/MAV:P/MAC:H/MPR:H/MUI:R/MS:C/MC:H/MI:H/MA:H
         metrics =
             CvssV3Calculation.fromVectorString(
                 "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H/E:U/RL:T/RC:U/CR:L/IR:L/AR:H/MAV:P/MAC:H/MPR:H/MUI:R/MS:C/MC:H/MI:H/MA:H"
             )
-        score = metrics.calculateEnvironmentalScore()
-        assertEquals(5.5, score)
+        assertEquals(5.5, metrics.environmentalScore)
+        assertEquals(Csaf.BaseSeverity.MEDIUM, metrics.environmentalSeverity)
 
         // https://www.first.org/cvss/calculator/3.1#CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H/E:U/RL:T/RC:U/CR:L/IR:L/AR:H/MAV:P/MAC:H/MPR:H/MUI:R/MS:C/MC:H/MI:H/MA:H
         metrics =
             CvssV3Calculation.fromVectorString(
                 "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H/E:U/RL:T/RC:U/CR:L/IR:L/AR:H/MAV:P/MAC:H/MPR:H/MUI:R/MS:C/MC:H/MI:H/MA:H"
             )
-        score = metrics.calculateEnvironmentalScore()
-        assertEquals(5.6, score)
+        assertEquals(5.6, metrics.environmentalScore)
+        assertEquals(Csaf.BaseSeverity.MEDIUM, metrics.environmentalSeverity)
     }
 }

--- a/csaf-cvss/src/test/kotlin/io/github/csaf/sbom/cvss/v3/CalculationTest.kt
+++ b/csaf-cvss/src/test/kotlin/io/github/csaf/sbom/cvss/v3/CalculationTest.kt
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2024, The Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.github.csaf.sbom.cvss.v3
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+
+class CalculationTest {
+
+    @Test
+    fun testFromVectorString() {
+        var ex =
+            assertFailsWith<IllegalArgumentException> { CvssV3Calculation.fromVectorString("") }
+        assertNotNull(ex)
+        assertEquals("Invalid CVSS format or version", ex.message)
+
+        ex = assertFailsWith<IllegalArgumentException> { CvssV3Calculation.fromVectorString("a/b") }
+        assertNotNull(ex)
+        assertEquals("Invalid CVSS format or version", ex.message)
+
+        ex =
+            assertFailsWith<IllegalArgumentException> {
+                CvssV3Calculation.fromVectorString("CVSS:3.2")
+            }
+        assertNotNull(ex)
+        assertEquals("Invalid CVSS format or version", ex.message)
+
+        ex =
+            assertFailsWith<IllegalArgumentException> {
+                CvssV3Calculation.fromVectorString("CVSS:3.0/b")
+            }
+        assertNotNull(ex)
+        assertEquals("Value for b is missing", ex.message)
+
+        ex =
+            assertFailsWith<IllegalArgumentException> {
+                CvssV3Calculation.fromVectorString("CVSS:3.0/AC:L/AC:H")
+            }
+        assertNotNull(ex)
+        assertEquals("Metric AC already defined", ex.message)
+    }
+
+    @Test
+    fun testCalculateBaseScore() {
+        var metrics =
+            CvssV3Calculation(
+                metrics =
+                    mapOf(
+                        "S" to "C",
+                        "C" to "L",
+                        "I" to "L",
+                        "A" to "N",
+                        "AV" to "N",
+                        "AC" to "L",
+                        "PR" to "N",
+                        "UI" to "R",
+                    )
+            )
+        var score = metrics.calculateBaseScore()
+        assertEquals(6.1, score)
+
+        metrics =
+            CvssV3Calculation(
+                metrics =
+                    mapOf(
+                        "S" to "U",
+                        "C" to "L",
+                        "I" to "N",
+                        "A" to "N",
+                        "AV" to "N",
+                        "AC" to "H",
+                        "PR" to "N",
+                        "UI" to "R",
+                    )
+            )
+        score = metrics.calculateBaseScore()
+        assertEquals(3.1, score)
+
+        // https://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:C/C:L/I:L/A:L
+        metrics = CvssV3Calculation.fromVectorString("CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:C/C:L/I:L/A:L")
+        score = metrics.calculateBaseScore()
+        assertEquals(7.4, score)
+
+        // https://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
+        metrics = CvssV3Calculation.fromVectorString("CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N")
+        score = metrics.calculateBaseScore()
+        assertEquals(0.0, score)
+
+        // https://www.first.org/cvss/calculator/3.1#CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N/RL:W
+        metrics =
+            CvssV3Calculation.fromVectorString("CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N/RL:W")
+        score = metrics.calculateBaseScore()
+        assertEquals(6.1, score)
+    }
+
+    @Test
+    fun testTemporalScore() {
+        // https://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:P/AC:H/PR:L/UI:R/S:U/C:L/I:L/A:H/E:H/RL:U/RC:U
+        var metrics =
+            CvssV3Calculation.fromVectorString(
+                "CVSS:3.0/AV:P/AC:H/PR:L/UI:R/S:U/C:L/I:L/A:H/E:H/RL:U/RC:U"
+            )
+        var score = metrics.calculateTemporalScore()
+        assertEquals(4.7, score)
+
+        // https://www.first.org/cvss/calculator/3.1#CVSS:3.1/AV:P/AC:H/PR:L/UI:R/S:U/C:L/I:L/A:H/E:H/RL:U/RC:U
+        metrics =
+            CvssV3Calculation.fromVectorString(
+                "CVSS:3.1/AV:P/AC:H/PR:L/UI:R/S:U/C:L/I:L/A:H/E:H/RL:U/RC:U"
+            )
+        score = metrics.calculateTemporalScore()
+        assertEquals(4.6, score)
+    }
+
+    @Test
+    fun testCalculateEnvironmentalScore() {
+        // https://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
+        var metrics =
+            CvssV3Calculation.fromVectorString("CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N")
+        var score = metrics.calculateEnvironmentalScore()
+        assertEquals(0.0, score)
+
+        // https://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+        metrics = CvssV3Calculation.fromVectorString("CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N")
+        score = metrics.calculateEnvironmentalScore()
+        assertEquals(7.5, score)
+
+        // https://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H/E:U/RL:T/RC:U/CR:L/IR:L/AR:H/MAV:P/MAC:H/MPR:H/MUI:R/MS:C/MC:H/MI:H/MA:H
+        metrics =
+            CvssV3Calculation.fromVectorString(
+                "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H/E:U/RL:T/RC:U/CR:L/IR:L/AR:H/MAV:P/MAC:H/MPR:H/MUI:R/MS:C/MC:H/MI:H/MA:H"
+            )
+        score = metrics.calculateEnvironmentalScore()
+        assertEquals(5.5, score)
+
+        // https://www.first.org/cvss/calculator/3.1#CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H/E:U/RL:T/RC:U/CR:L/IR:L/AR:H/MAV:P/MAC:H/MPR:H/MUI:R/MS:C/MC:H/MI:H/MA:H
+        metrics =
+            CvssV3Calculation.fromVectorString(
+                "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H/E:U/RL:T/RC:U/CR:L/IR:L/AR:H/MAV:P/MAC:H/MPR:H/MUI:R/MS:C/MC:H/MI:H/MA:H"
+            )
+        score = metrics.calculateEnvironmentalScore()
+        assertEquals(5.6, score)
+    }
+}

--- a/csaf-cvss/src/test/kotlin/io/github/csaf/sbom/cvss/v3/CalculationTest.kt
+++ b/csaf-cvss/src/test/kotlin/io/github/csaf/sbom/cvss/v3/CalculationTest.kt
@@ -184,10 +184,17 @@ class CalculationTest {
         )
 
         // Almost identical vector compared to the one above, but with "MS:X" to check the scope
-        // "fallback" to "S:C".
+        // "fallback" to "S:C" and "S:U".
         verifyEnvironmentalScore(
             "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H/E:U/RL:T/RC:U/CR:L/IR:L/AR:H/MAV:P/MAC:H/MPR:H/MUI:R/MS:X/MC:H/MI:H/MA:H",
             5.6,
+            Csaf.BaseSeverity.MEDIUM
+        )
+        // Almost identical vector compared to the one above, but also with "S:U" to cover the last
+        // execution path.
+        verifyEnvironmentalScore(
+            "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/E:U/RL:T/RC:U/CR:L/IR:L/AR:H/MAV:P/MAC:H/MPR:H/MUI:R/MS:X/MC:H/MI:H/MA:H",
+            4.9,
             Csaf.BaseSeverity.MEDIUM
         )
     }

--- a/csaf-cvss/src/test/kotlin/io/github/csaf/sbom/cvss/v3/CalculationTest.kt
+++ b/csaf-cvss/src/test/kotlin/io/github/csaf/sbom/cvss/v3/CalculationTest.kt
@@ -182,5 +182,13 @@ class CalculationTest {
             5.6,
             Csaf.BaseSeverity.MEDIUM
         )
+
+        // Almost identical vector compared to the one above, but with "MS:X" to check the scope
+        // "fallback" to "S:C".
+        verifyEnvironmentalScore(
+            "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H/E:U/RL:T/RC:U/CR:L/IR:L/AR:H/MAV:P/MAC:H/MPR:H/MUI:R/MS:X/MC:H/MI:H/MA:H",
+            5.6,
+            Csaf.BaseSeverity.MEDIUM
+        )
     }
 }

--- a/csaf-schema/src/main/resources/schema/csaf_json_schema.json
+++ b/csaf-schema/src/main/resources/schema/csaf_json_schema.json
@@ -1351,11 +1351,10 @@
               "minProperties": 2,
               "properties": {
                 "cvss_v2": {
-                  "$ref": "https://www.first.org/cvss/cvss-v2.0.json"
+                  "$ref": "https://csrc.nist.gov/schema/nvd/feed/1.1/cvss-v2.0.json"
                 },
                 "cvss_v3": {
-                  "format": "generic",
-                  "type": "object"
+                  "$ref": "https://csrc.nist.gov/schema/nvd/feed/1.1/cvss-v3.x.json"
                 },
                 "products": {
                   "$ref": "#/$defs/products_t"

--- a/csaf-validation/build.gradle.kts
+++ b/csaf-validation/build.gradle.kts
@@ -16,6 +16,7 @@ mavenPublishing {
 
 dependencies {
     implementation(project(":csaf-schema"))
+    implementation(project(":csaf-cvss"))
     implementation(libs.ktor.client.core)
     testImplementation(libs.bundles.ktor.client)
     testImplementation(libs.ktor.client.mock)

--- a/csaf-validation/src/main/kotlin/io/github/csaf/sbom/validation/Test.kt
+++ b/csaf-validation/src/main/kotlin/io/github/csaf/sbom/validation/Test.kt
@@ -50,7 +50,7 @@ interface Test {
             val doc = Json.decodeFromString<Csaf>(Path(path).readText())
             return this.test(doc)
         } catch (ex: SerializationException) {
-            return ValidationFailed(listOf(ex.message ?: "serialization failed"))
+            return ex.toValidationResult()
         }
     }
 }

--- a/csaf-validation/src/main/kotlin/io/github/csaf/sbom/validation/ValidationResult.kt
+++ b/csaf-validation/src/main/kotlin/io/github/csaf/sbom/validation/ValidationResult.kt
@@ -52,3 +52,7 @@ fun List<ValidationResult>.merge(): ValidationResult {
         ValidationSuccessful
     }
 }
+
+fun Exception.toValidationResult(): ValidationFailed {
+    return ValidationFailed(listOfNotNull(this.message))
+}

--- a/csaf-validation/src/main/kotlin/io/github/csaf/sbom/validation/tests/Tests.kt
+++ b/csaf-validation/src/main/kotlin/io/github/csaf/sbom/validation/tests/Tests.kt
@@ -16,6 +16,7 @@
  */
 package io.github.csaf.sbom.validation.tests
 
+import io.github.csaf.sbom.cvss.MetricValue
 import io.github.csaf.sbom.cvss.v3.CvssV3Calculation
 import io.github.csaf.sbom.schema.generated.Csaf
 import io.github.csaf.sbom.validation.Test
@@ -42,6 +43,7 @@ var mandatoryTests =
         Test617MultipleScoresWithSameVersionPerProduct,
         Test618InvalidCVSS,
         Test619InvalidCVSSComputation,
+        Test6110InconsistentCVSS
     )
 
 /**
@@ -268,7 +270,7 @@ object Test618InvalidCVSS : Test {
     }
 }
 
-val propertyMap =
+val test619PropertiesMap =
     mapOf<KProperty1<Csaf.CvssV3, Any?>, KProperty1<CvssV3Calculation, Any>>(
         Csaf.CvssV3::baseScore to CvssV3Calculation::baseScore,
         Csaf.CvssV3::baseSeverity to CvssV3Calculation::baseSeverity,
@@ -292,8 +294,8 @@ object Test619InvalidCVSSComputation : Test {
                 // (Re)-Calculate the score
                 val calc = CvssV3Calculation.fromVectorString(it.vectorString)
 
-                // Check the following properties for consistency
-                for (entry in propertyMap) {
+                // Check the following properties for validity
+                for (entry in test619PropertiesMap) {
                     val documentValue = entry.key.get(it)
                     val calculatedValue = entry.value.get(calc)
 
@@ -312,6 +314,69 @@ object Test619InvalidCVSSComputation : Test {
             ValidationFailed(
                 listOf(
                     "The following properties are invalid: ${invalids.map{ "${it.first}: ${it.second.first} != ${it.second.second}"}.joinToString(", ")}"
+                )
+            )
+        }
+    }
+}
+
+val test6110PropertiesMap =
+    mapOf<KProperty1<Csaf.CvssV3, Any?>, KProperty1<CvssV3Calculation, MetricValue<*>>>(
+        Csaf.CvssV3::attackVector to CvssV3Calculation::attackVector,
+        Csaf.CvssV3::attackComplexity to CvssV3Calculation::attackComplexity,
+        Csaf.CvssV3::privilegesRequired to CvssV3Calculation::privilegesRequired,
+        Csaf.CvssV3::userInteraction to CvssV3Calculation::userInteraction,
+        Csaf.CvssV3::scope to CvssV3Calculation::scope,
+        Csaf.CvssV3::confidentialityImpact to CvssV3Calculation::confidentialityImpact,
+        Csaf.CvssV3::integrityImpact to CvssV3Calculation::integrityImpact,
+        Csaf.CvssV3::availabilityImpact to CvssV3Calculation::availabilityImpact,
+        Csaf.CvssV3::exploitCodeMaturity to CvssV3Calculation::exploitCodeMaturity,
+        Csaf.CvssV3::remediationLevel to CvssV3Calculation::remediationLevel,
+        Csaf.CvssV3::confidentialityRequirement to CvssV3Calculation::confidentialityRequirement,
+        Csaf.CvssV3::integrityRequirement to CvssV3Calculation::integrityRequirement,
+        Csaf.CvssV3::availabilityRequirement to CvssV3Calculation::availabilityRequirement,
+        Csaf.CvssV3::modifiedAttackVector to CvssV3Calculation::modifiedAttackVector,
+        Csaf.CvssV3::modifiedAttackComplexity to CvssV3Calculation::modifiedAttackComplexity,
+        Csaf.CvssV3::modifiedPrivilegesRequired to CvssV3Calculation::modifiedPrivilegesRequired,
+        Csaf.CvssV3::modifiedUserInteraction to CvssV3Calculation::modifiedUserInteraction,
+        Csaf.CvssV3::modifiedScope to CvssV3Calculation::modifiedScope,
+        Csaf.CvssV3::modifiedConfidentialityImpact to
+            CvssV3Calculation::modifiedConfidentialityImpact,
+        Csaf.CvssV3::modifiedIntegrityImpact to CvssV3Calculation::modifiedIntegrityImpact,
+        Csaf.CvssV3::modifiedAvailabilityImpact to CvssV3Calculation::modifiedAvailabilityImpact
+    )
+
+object Test6110InconsistentCVSS : Test {
+    override fun test(doc: Csaf): ValidationResult {
+        val inconsistencies = mutableSetOf<Pair<String, Pair<Any?, Any>>>()
+        for (score in doc.vulnerabilities?.flatMap { it.scores ?: listOf() } ?: listOf()) {
+            // TODO(oxisto): CVSS2
+
+            score.cvss_v3?.let {
+                // Parse the vector string
+                val calc = CvssV3Calculation.fromVectorString(it.vectorString)
+
+                // Check the following properties for consistency
+                for (entry in test6110PropertiesMap) {
+                    val documentValue = entry.key.get(it)
+                    val calculatedValue = entry.value.get(calc).enumValue
+
+                    // Compare the values. Since it is allowed to skip values in the CSAF document,
+                    // we only compare non-null values
+                    if (documentValue != null && documentValue != calculatedValue) {
+                        inconsistencies +=
+                            Pair(entry.key.name, Pair(documentValue, calculatedValue))
+                    }
+                }
+            }
+        }
+
+        return if (inconsistencies.isEmpty()) {
+            ValidationSuccessful
+        } else {
+            ValidationFailed(
+                listOf(
+                    "The following properties are inconsistent: ${inconsistencies.map{ "${it.first}: ${it.second.first} != ${it.second.second}"}.joinToString(", ")}"
                 )
             )
         }

--- a/csaf-validation/src/main/kotlin/io/github/csaf/sbom/validation/tests/Tests.kt
+++ b/csaf-validation/src/main/kotlin/io/github/csaf/sbom/validation/tests/Tests.kt
@@ -270,7 +270,7 @@ object Test618InvalidCVSS : Test {
     }
 }
 
-val test619PropertiesMap =
+val test619V3PropertiesMap =
     mapOf<KProperty1<Csaf.CvssV3, Any?>, KProperty1<CvssV3Calculation, Any>>(
         Csaf.CvssV3::baseScore to CvssV3Calculation::baseScore,
         Csaf.CvssV3::baseSeverity to CvssV3Calculation::baseSeverity,
@@ -295,7 +295,7 @@ object Test619InvalidCVSSComputation : Test {
                 val calc = CvssV3Calculation.fromVectorString(it.vectorString)
 
                 // Check the following properties for validity
-                for (entry in test619PropertiesMap) {
+                for (entry in test619V3PropertiesMap) {
                     val documentValue = entry.key.get(it)
                     val calculatedValue = entry.value.get(calc)
 

--- a/csaf-validation/src/main/kotlin/io/github/csaf/sbom/validation/tests/Tests.kt
+++ b/csaf-validation/src/main/kotlin/io/github/csaf/sbom/validation/tests/Tests.kt
@@ -25,8 +25,6 @@ import io.github.csaf.sbom.validation.ValidationResult
 import io.github.csaf.sbom.validation.ValidationSuccessful
 import io.github.csaf.sbom.validation.merge
 import kotlin.reflect.KProperty1
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonPrimitive
 
 /**
  * Mandatory tests as defined in
@@ -400,13 +398,3 @@ object Test621UnusedDefinitionOfProductID : Test {
         }
     }
 }
-
-val JsonObject?.version: String?
-    get() {
-        val primitive = this?.get("version") as? JsonPrimitive
-        return if (primitive?.isString == true) {
-            primitive.content
-        } else {
-            null
-        }
-    }

--- a/csaf-validation/src/test/kotlin/io/github/csaf/sbom/validation/tests/TestsTest.kt
+++ b/csaf-validation/src/test/kotlin/io/github/csaf/sbom/validation/tests/TestsTest.kt
@@ -23,9 +23,6 @@ import io.github.csaf.sbom.validation.assertValidationSuccessful
 import io.github.csaf.sbom.validation.requirements.goodCsaf
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonPrimitive
 
 /** The path to the test folder for the CSAF 2.0 tests. */
 var testFolder: String = "../csaf/csaf_2.0/test/validator/data/"
@@ -236,14 +233,5 @@ class TestsTest {
                 "${it::class.simpleName} was not successful"
             )
         }
-    }
-
-    @OptIn(ExperimentalSerializationApi::class)
-    @Test
-    fun testVersion() {
-        @Suppress("USELESS_CAST") assertEquals(null, (null as? JsonObject).version)
-        assertEquals(null, JsonObject(content = mapOf()).version)
-        assertEquals(null, JsonObject(content = mapOf("version" to JsonPrimitive(null))).version)
-        assertEquals("3.0", JsonObject(content = mapOf("version" to JsonPrimitive("3.0"))).version)
     }
 }

--- a/csaf-validation/src/test/kotlin/io/github/csaf/sbom/validation/tests/TestsTest.kt
+++ b/csaf-validation/src/test/kotlin/io/github/csaf/sbom/validation/tests/TestsTest.kt
@@ -17,17 +17,13 @@
 package io.github.csaf.sbom.validation.tests
 
 import io.github.csaf.sbom.schema.generated.Csaf
-import io.github.csaf.sbom.validation.ValidationResult
 import io.github.csaf.sbom.validation.ValidationSuccessful
 import io.github.csaf.sbom.validation.assertValidationFailed
 import io.github.csaf.sbom.validation.assertValidationSuccessful
 import io.github.csaf.sbom.validation.requirements.goodCsaf
-import kotlin.io.path.Path
-import kotlin.io.path.readText
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 
@@ -48,12 +44,6 @@ fun mandatoryTest(id: String): String {
  */
 fun optionalTest(id: String): String {
     return "$testFolder/optional/oasis_csaf_tc-csaf_2_0-2021-${id}.json"
-}
-
-/** Extension function to test a JSON file given in the [path]. */
-fun io.github.csaf.sbom.validation.Test.test(path: String): ValidationResult {
-    val doc = Json.decodeFromString<Csaf>(Path(path).readText())
-    return this.test(doc)
 }
 
 class TestsTest {
@@ -163,6 +153,42 @@ class TestsTest {
         )
         assertValidationSuccessful(test.test(mandatoryTest("6-1-07-11")))
         assertValidationSuccessful(test.test(mandatoryTest("6-1-07-12")))
+    }
+
+    @Test
+    fun test618() {
+        val test = Test618InvalidCVSS
+
+        // failing examples
+        assertValidationFailed(
+            "Field 'baseSeverity' is required for type with serial name 'io.github.csaf.sbom.schema.generated.Csaf.CvssV3', but it was missing at path: \$.vulnerabilities[0].scores[0].cvss_v3",
+            test.test(mandatoryTest("6-1-08-01"))
+        )
+        assertValidationFailed(
+            "Field 'baseSeverity' is required for type with serial name 'io.github.csaf.sbom.schema.generated.Csaf.CvssV3', but it was missing at path: \$.vulnerabilities[0].scores[0].cvss_v3",
+            test.test(mandatoryTest("6-1-08-02"))
+        )
+        assertValidationFailed(
+            "Field 'version' is required for type with serial name 'io.github.csaf.sbom.schema.generated.Csaf.CvssV2', but it was missing at path: \$.vulnerabilities[0].scores[0].cvss_v2",
+            test.test(mandatoryTest("6-1-08-03"))
+        )
+
+        // good examples
+        assertValidationSuccessful(test.test(mandatoryTest("6-1-08-11")))
+        assertValidationSuccessful(test.test(mandatoryTest("6-1-08-12")))
+        assertValidationSuccessful(test.test(mandatoryTest("6-1-08-13")))
+        assertValidationSuccessful(test.test(mandatoryTest("6-1-08-14")))
+    }
+
+    @Test
+    fun test619() {
+        val test = Test619InvalidCVSSComputation
+
+        // failing examples
+        assertValidationFailed(
+            "The following properties are invalid: baseScore: 10.0 != 6.5, baseSeverity: LOW != MEDIUM",
+            test.test(mandatoryTest("6-1-09-01"))
+        )
     }
 
     @Test

--- a/csaf-validation/src/test/kotlin/io/github/csaf/sbom/validation/tests/TestsTest.kt
+++ b/csaf-validation/src/test/kotlin/io/github/csaf/sbom/validation/tests/TestsTest.kt
@@ -192,6 +192,26 @@ class TestsTest {
 
         // good examples
         assertValidationSuccessful(test.test(goodCsaf(vulnerabilities = null)))
+        assertValidationSuccessful(
+            test.test(goodCsaf(vulnerabilities = listOf(Csaf.Vulnerability(scores = null))))
+        )
+    }
+
+    @Test
+    fun test6110() {
+        val test = Test6110InconsistentCVSS
+
+        // failing examples
+        assertValidationFailed(
+            "The following properties are inconsistent: attackVector: LOCAL != NETWORK, scope: CHANGED != UNCHANGED, availabilityImpact: LOW != HIGH",
+            test.test(mandatoryTest("6-1-10-01"))
+        )
+
+        // good examples
+        assertValidationSuccessful(test.test(goodCsaf(vulnerabilities = null)))
+        assertValidationSuccessful(
+            test.test(goodCsaf(vulnerabilities = listOf(Csaf.Vulnerability(scores = null))))
+        )
     }
 
     @Test

--- a/csaf-validation/src/test/kotlin/io/github/csaf/sbom/validation/tests/TestsTest.kt
+++ b/csaf-validation/src/test/kotlin/io/github/csaf/sbom/validation/tests/TestsTest.kt
@@ -189,6 +189,9 @@ class TestsTest {
             "The following properties are invalid: baseScore: 10.0 != 6.5, baseSeverity: LOW != MEDIUM",
             test.test(mandatoryTest("6-1-09-01"))
         )
+
+        // good examples
+        assertValidationSuccessful(test.test(goodCsaf(vulnerabilities = null)))
     }
 
     @Test

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,4 +13,4 @@ plugins {
 }
 
 rootProject.name = "kotlin-csaf"
-include("csaf-schema", "csaf-import", "csaf-validation")
+include("csaf-schema", "csaf-import", "csaf-validation", "csaf-cvss")


### PR DESCRIPTION
This PR adds the mandatory tests for CSAF document conformance related to the CVSS standard. Since no CVSS standard implementation is available in pure Kotlin, we decided to implement CVSS v2 and v3 in a separate module `csaf-cvss` and employ our solution in the validation tests.

Depends on #67   