### PR TITLE
Back to 100 % test coverage for `csaf-cvss` coverage

### DIFF
--- a/csaf-cvss/src/main/kotlin/io/github/csaf/sbom/cvss/v3/Calculation.kt
+++ b/csaf-cvss/src/main/kotlin/io/github/csaf/sbom/cvss/v3/Calculation.kt
@@ -205,10 +205,14 @@ class CvssV3Calculation(
                 ModifiedScope.UNCHANGED to Pair("U", 0.0),
             )
         )
-    val modifiedScopeChanged
-        get() =
-            modifiedScope.enumValue == ModifiedScope.CHANGED ||
-                (modifiedScope.enumValue == ModifiedScope.NOT_DEFINED && scopeChanged)
+    val modifiedScopeChanged: Boolean
+        get() {
+            return when (modifiedScope.enumValue) {
+                ModifiedScope.CHANGED -> true
+                ModifiedScope.UNCHANGED -> false
+                ModifiedScope.NOT_DEFINED -> scopeChanged
+            }
+        }
 
     val modifiedAttackVector by
         optionalMetric(

--- a/csaf-cvss/src/test/kotlin/io/github/csaf/sbom/cvss/v3/CalculationTest.kt
+++ b/csaf-cvss/src/test/kotlin/io/github/csaf/sbom/cvss/v3/CalculationTest.kt
@@ -183,6 +183,13 @@ class CalculationTest {
             Csaf.BaseSeverity.MEDIUM
         )
 
+        // https://www.first.org/cvss/calculator/3.1#CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H/E:U/RL:T/RC:U/CR:L/IR:L/AR:H/MAV:P/MAC:H/MPR:H/MUI:R/MS:U/MC:H/MI:H/MA:H
+        verifyEnvironmentalScore(
+            "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H/E:U/RL:T/RC:U/CR:L/IR:L/AR:H/MAV:P/MAC:H/MPR:H/MUI:R/MS:U/MC:H/MI:H/MA:H",
+            4.9,
+            Csaf.BaseSeverity.MEDIUM
+        )
+
         // Almost identical vector compared to the one above, but with "MS:X" to check the scope
         // "fallback" to "S:C" and "S:U".
         verifyEnvironmentalScore(
@@ -190,6 +197,7 @@ class CalculationTest {
             5.6,
             Csaf.BaseSeverity.MEDIUM
         )
+
         // Almost identical vector compared to the one above, but also with "S:U" to cover the last
         // execution path.
         verifyEnvironmentalScore(


### PR DESCRIPTION
Fixes the test coverage back up to 100 % by catching the last branch. Also sligthly reworked the getter for `modifiedScope` to better illustrate the branches. This actually helped me in catching the last missing non-covered branch.
