### PR TITLE
Implementation of (semi) automatically update for CSAF test files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/csaf-validation/build.gradle.kts
+++ b/csaf-validation/build.gradle.kts
@@ -2,12 +2,14 @@ import de.undercouch.gradle.tasks.download.Download
 import groovy.json.JsonOutput
 import groovy.xml.XmlParser
 import org.gradle.kotlin.dsl.invoke
+import net.pwall.json.kotlin.codegen.gradle.JSONSchemaCodegen
+import kotlin.text.set
 
 plugins {
     id("buildlogic.kotlin-library-conventions")
+    id("net.pwall.json.json-kotlin")
     id("de.undercouch.download") version "5.6.0"
     kotlin("plugin.serialization")
-
     `java-test-fixtures`
     application
 }
@@ -57,6 +59,14 @@ open class IncrementalReverseTask : DefaultTask() {
 
         outputFile.asFile.get().writeText(JsonOutput.toJson(map))
     }
+}
+
+configure<JSONSchemaCodegen> {
+    //configFile.set(file("src/main/resources/codegen-config.json"))
+    inputs {
+        inputFile(file("../csaf/csaf2.0/test/validator/testcases_json_schema.json"))
+    }
+    outputDir.set(file("build/generated-sources/kotlin"))
 }
 
 tasks {

--- a/csaf-validation/build.gradle.kts
+++ b/csaf-validation/build.gradle.kts
@@ -3,7 +3,9 @@ import groovy.json.JsonOutput
 import groovy.xml.XmlParser
 import org.gradle.kotlin.dsl.invoke
 import net.pwall.json.kotlin.codegen.gradle.JSONSchemaCodegen
-import kotlin.text.set
+import net.pwall.json.kotlin.codegen.gradle.JSONSchemaCodegenTask
+import org.gradle.kotlin.dsl.withType
+import org.jetbrains.dokka.gradle.DokkaTask
 
 plugins {
     id("buildlogic.kotlin-library-conventions")
@@ -34,6 +36,33 @@ dependencies {
     implementation("net.swiftzer.semver:semver:2.0.0")
     testImplementation(libs.bundles.ktor.client)
     testImplementation(libs.ktor.client.mock)
+    testImplementation(libs.kotlinx.json)
+}
+
+configure<JSONSchemaCodegen> {
+    configFile.set(file("src/main/resources/codegen-config.json"))
+    inputs {
+        inputFile(file("../csaf/csaf_2.0/test/validator/testcases_json_schema.json"))
+    }
+    outputDir.set(file("build/generated-sources/kotlin"))
+}
+
+// Configure gradle caching manually for json-kotlin-gradle, as the plugin seems to lack support for it.
+var generateTasks = tasks.withType(JSONSchemaCodegenTask::class) {
+    inputs.file("src/main/resources/codegen-config.json").withPathSensitivity(PathSensitivity.RELATIVE)
+    inputs.dir("../csaf/csaf_2.0/test/validator/").withPathSensitivity(PathSensitivity.RELATIVE)
+    outputs.dir("build/generated-sources/kotlin")
+}
+
+var jarTasks = tasks.withType<Jar>()
+jarTasks.forEach {
+    it.dependsOn(generateTasks)
+}
+val dokkaHtml by tasks.getting(DokkaTask::class)
+dokkaHtml.dependsOn(generateTasks)
+
+sourceSets.main {
+    kotlin.srcDirs("build/generated-sources/kotlin")
 }
 
 open class IncrementalReverseTask : DefaultTask() {
@@ -59,14 +88,6 @@ open class IncrementalReverseTask : DefaultTask() {
 
         outputFile.asFile.get().writeText(JsonOutput.toJson(map))
     }
-}
-
-configure<JSONSchemaCodegen> {
-    //configFile.set(file("src/main/resources/codegen-config.json"))
-    inputs {
-        inputFile(file("../csaf/csaf2.0/test/validator/testcases_json_schema.json"))
-    }
-    outputDir.set(file("build/generated-sources/kotlin"))
 }
 
 tasks {

--- a/csaf-validation/src/main/kotlin/io/github/csaf/sbom/validation/tests/Tests.kt
+++ b/csaf-validation/src/main/kotlin/io/github/csaf/sbom/validation/tests/Tests.kt
@@ -750,6 +750,10 @@ object Test6128Translation : Test {
  */
 object Test621UnusedDefinitionOfProductID : Test {
     override fun test(doc: Csaf): ValidationResult {
+        if (doc.document.category == "csaf_informational_advisory") {
+            return ValidationNotApplicable
+        }
+
         val definitions = doc.gatherProductDefinitions()
         val references = doc.gatherProductReferences()
 

--- a/csaf-validation/src/main/resources/codegen-config.json
+++ b/csaf-validation/src/main/resources/codegen-config.json
@@ -1,0 +1,16 @@
+{
+  "packageName": "io.github.csaf.sbom.validation.generated",
+  "annotations": {
+    "classes": {
+      "kotlinx.serialization.Serializable": null
+    }
+  },
+  "customClasses": {
+    "format": {
+      "uri": "io.github.csaf.sbom.schema.JsonUri",
+      "date-time": "io.github.csaf.sbom.schema.JsonOffsetDateTime",
+      "generic": "kotlinx.serialization.json.JsonObject"
+    }
+  },
+  "decimalClassName": "kotlin.Double"
+}

--- a/csaf-validation/src/test/kotlin/io/github/csaf/sbom/validation/tests/TestsTest.kt
+++ b/csaf-validation/src/test/kotlin/io/github/csaf/sbom/validation/tests/TestsTest.kt
@@ -22,8 +22,8 @@ import io.github.csaf.sbom.schema.generated.Csaf
 import io.github.csaf.sbom.validation.ValidationSuccessful
 import io.github.csaf.sbom.validation.assertValidationFailed
 import io.github.csaf.sbom.validation.assertValidationSuccessful
-import io.github.csaf.sbom.validation.goodCsaf
 import io.github.csaf.sbom.validation.generated.Testcases
+import io.github.csaf.sbom.validation.goodCsaf
 import kotlin.io.path.Path
 import kotlin.io.path.readText
 import kotlin.test.AfterTest

--- a/csaf-validation/src/test/kotlin/io/github/csaf/sbom/validation/tests/TestsTest.kt
+++ b/csaf-validation/src/test/kotlin/io/github/csaf/sbom/validation/tests/TestsTest.kt
@@ -23,29 +23,33 @@ import io.github.csaf.sbom.validation.ValidationSuccessful
 import io.github.csaf.sbom.validation.assertValidationFailed
 import io.github.csaf.sbom.validation.assertValidationSuccessful
 import io.github.csaf.sbom.validation.goodCsaf
+import io.github.csaf.sbom.validation.generated.Testcases
+import kotlin.io.path.Path
+import kotlin.io.path.readText
+import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlinx.serialization.json.Json
 
 /** The path to the test folder for the CSAF 2.0 tests. */
 var testFolder: String = "../csaf/csaf_2.0/test/validator/data/"
 
-/**
- * Short utility function to construct the path to the test file based on the test file ID for
- * mandatory tests.
- */
-fun mandatoryTest(id: String): String {
-    return "$testFolder/mandatory/oasis_csaf_tc-csaf_2_0-2021-${id}.json"
-}
-
-/**
- * Short utility function to construct the path to the test file based on the test file ID for
- * optional tests.
- */
-fun optionalTest(id: String): String {
-    return "$testFolder/optional/oasis_csaf_tc-csaf_2_0-2021-${id}.json"
-}
-
 class TestsTest {
+
+    val executedTests = mutableSetOf<String>()
+
+    companion object {
+        val testCases =
+            Json { ignoreUnknownKeys = true }
+                .decodeFromString<Testcases>(Path("$testFolder/testcases.json").readText())
+    }
+
+    @AfterTest
+    fun checkAllTestCases() {
+        // Try to find the test 
+        println(executedTests)
+    }
+
     @Test
     fun test611() {
         val test = Test611MissingDefinitionOfProductID
@@ -724,5 +728,27 @@ class TestsTest {
                 "${it::class.simpleName} was not successful",
             )
         }
+    }
+
+    /**
+     * Short utility function to construct the path to the test file based on the test file ID for
+     * mandatory tests.
+     */
+    fun mandatoryTest(id: String): String {
+        var test = "mandatory/oasis_csaf_tc-csaf_2_0-2021-${id}.json"
+        executedTests += test
+
+        return "$testFolder/$test"
+    }
+
+    /**
+     * Short utility function to construct the path to the test file based on the test file ID for
+     * optional tests.
+     */
+    fun optionalTest(id: String): String {
+        var test = "optional/oasis_csaf_tc-csaf_2_0-2021-${id}.json"
+        executedTests += test
+
+        return "$testFolder/$test"
     }
 }


### PR DESCRIPTION
This PR adds a mechanism to trigger updates to the CSAF test files. It works on several layers:
- Dependabot is configured to watch for updates in the TC repo and open a PR
- We parse the information in the `testcases.json` in the TC repo and keep track of executed test files for each validation test. If there is a missing test file, we fail the unit test

This will allow us to get informed about new tests (or test changes) if the PR opened by dependabot fails.

Fun fact, this already proved that its worked, because I actually missed a test case for 6.2.1.