### PR TITLE
Adding `RetrievedAggregator::fromAsync`

### DIFF
--- a/csaf-retrieval/src/jvmMain/kotlin/io/github/csaf/sbom/retrieval/RetrievedAggregator.kt
+++ b/csaf-retrieval/src/jvmMain/kotlin/io/github/csaf/sbom/retrieval/RetrievedAggregator.kt
@@ -20,6 +20,11 @@ import io.github.csaf.sbom.retrieval.CsafLoader.Companion.lazyLoader
 import io.github.csaf.sbom.retrieval.roles.CSAFAggregatorRole
 import io.github.csaf.sbom.retrieval.roles.CSAFListerRole
 import io.github.csaf.sbom.schema.generated.Aggregator
+import java.util.concurrent.CompletableFuture
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.future.future
 
 /**
  * This class represents a wrapper around a [Aggregator] document, that provides functionality for
@@ -85,6 +90,17 @@ class RetrievedAggregator(val json: Aggregator) : Validatable {
     }
 
     companion object {
+        private val ioScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+
+        @JvmStatic
+        @JvmOverloads
+        fun fromAsync(
+            domain: String,
+            loader: CsafLoader = lazyLoader,
+        ): CompletableFuture<RetrievedAggregator> {
+            return ioScope.future { from(domain, loader).getOrThrow() }
+        }
+
         /**
          * Retrieves an [Aggregator] from a given [url].
          *

--- a/csaf-retrieval/src/jvmTest/java/io/github/csaf/sbom/retrieval/RetrievedAggregatorJavaTest.java
+++ b/csaf-retrieval/src/jvmTest/java/io/github/csaf/sbom/retrieval/RetrievedAggregatorJavaTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2024, The Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.github.csaf.sbom.retrieval;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Tests the functionality of <code>{@link RetrievedAggregator}</code> in Java.
+ */
+public class RetrievedAggregatorJavaTest {
+    private static CsafLoader loader;
+
+    public RetrievedAggregatorJavaTest() {
+        loader = new CsafLoader(TestUtilsKt.mockEngine());
+        //noinspection KotlinInternalInJava
+        CsafLoader.Companion.setDefaultLoaderFactory$csaf_retrieval(() -> loader);
+    }
+
+    @Test
+    public void testRetrievedAggregatorJava() throws InterruptedException, ExecutionException {
+        final var aggregator = RetrievedAggregator.fromAsync("https://example.com/example-01-lister.json").get();
+        assertNotNull(aggregator);
+    }
+}


### PR DESCRIPTION
Exposes the aggregator to pure Java projects. Fixes #150
