### PR TITLE
Fix inconsistencies in CVSS calculations

### DIFF
--- a/csaf-cvss/src/commonMain/kotlin/io/github/csaf/sbom/cvss/Extensions.kt
+++ b/csaf-cvss/src/commonMain/kotlin/io/github/csaf/sbom/cvss/Extensions.kt
@@ -18,6 +18,7 @@ package io.github.csaf.sbom.cvss
 
 import io.github.csaf.sbom.schema.generated.Csaf.BaseSeverity
 
+@Suppress("KotlinConstantConditions")
 fun Double.toSeverity(): BaseSeverity {
     return when {
         this == 0.0 -> BaseSeverity.NONE

--- a/csaf-cvss/src/commonMain/kotlin/io/github/csaf/sbom/cvss/v3/Calculation.kt
+++ b/csaf-cvss/src/commonMain/kotlin/io/github/csaf/sbom/cvss/v3/Calculation.kt
@@ -160,30 +160,30 @@ class CvssV3Calculation(override val metrics: Map<String, String>) : CvssCalcula
         optionalMetric(
             "CR",
             mapOf(
-                ConfidentialityRequirement.NOT_DEFINED to Pair("X", 1.0),
-                ConfidentialityRequirement.HIGH to Pair("H", 1.5),
-                ConfidentialityRequirement.MEDIUM to Pair("M", 1.0),
-                ConfidentialityRequirement.LOW to Pair("L", 0.5),
+                ConfidentialityRequirement1.NOT_DEFINED to Pair("X", 1.0),
+                ConfidentialityRequirement1.HIGH to Pair("H", 1.5),
+                ConfidentialityRequirement1.MEDIUM to Pair("M", 1.0),
+                ConfidentialityRequirement1.LOW to Pair("L", 0.5),
             ),
         )
     val integrityRequirement by
-        optionalMetric<ConfidentialityRequirement>(
+        optionalMetric<ConfidentialityRequirement1>(
             "IR",
             mapOf(
-                ConfidentialityRequirement.NOT_DEFINED to Pair("X", 1.0),
-                ConfidentialityRequirement.HIGH to Pair("H", 1.5),
-                ConfidentialityRequirement.MEDIUM to Pair("M", 1.0),
-                ConfidentialityRequirement.LOW to Pair("L", 0.5),
+                ConfidentialityRequirement1.NOT_DEFINED to Pair("X", 1.0),
+                ConfidentialityRequirement1.HIGH to Pair("H", 1.5),
+                ConfidentialityRequirement1.MEDIUM to Pair("M", 1.0),
+                ConfidentialityRequirement1.LOW to Pair("L", 0.5),
             ),
         )
     val availabilityRequirement by
-        optionalMetric<ConfidentialityRequirement>(
+        optionalMetric<ConfidentialityRequirement1>(
             "AR",
             mapOf(
-                ConfidentialityRequirement.NOT_DEFINED to Pair("X", 1.0),
-                ConfidentialityRequirement.HIGH to Pair("H", 1.5),
-                ConfidentialityRequirement.MEDIUM to Pair("M", 1.0),
-                ConfidentialityRequirement.LOW to Pair("L", 0.5),
+                ConfidentialityRequirement1.NOT_DEFINED to Pair("X", 1.0),
+                ConfidentialityRequirement1.HIGH to Pair("H", 1.5),
+                ConfidentialityRequirement1.MEDIUM to Pair("M", 1.0),
+                ConfidentialityRequirement1.LOW to Pair("L", 0.5),
             ),
         )
 

--- a/csaf-validation/src/commonMain/kotlin/io/github/csaf/sbom/validation/tests/Tests.kt
+++ b/csaf-validation/src/commonMain/kotlin/io/github/csaf/sbom/validation/tests/Tests.kt
@@ -356,7 +356,11 @@ object Test619InvalidCVSSComputation : Test {
         } else {
             ValidationFailed(
                 listOf(
-                    "The following properties are invalid: ${invalids.map{ "${it.first}: ${it.second.first} != ${it.second.second}"}.joinToString(", ")}"
+                    "The following properties are invalid: ${
+                        invalids.joinToString(", ") {
+                            "${it.first}: ${it.second.first} != ${it.second.second}"
+                        }
+                    }"
                 )
             )
         }
@@ -423,7 +427,11 @@ object Test6110InconsistentCVSS : Test {
         } else {
             ValidationFailed(
                 listOf(
-                    "The following properties are inconsistent: ${inconsistencies.map{ "${it.first}: ${it.second.first} != ${it.second.second}"}.joinToString(", ")}"
+                    "The following properties are inconsistent: ${
+                        inconsistencies.joinToString(", ") {
+                            "${it.first}: ${it.second.first} != ${it.second.second}"
+                        }
+                    }"
                 )
             )
         }
@@ -643,7 +651,9 @@ object Test6118ReleasedRevisionHistory : Test {
         } else {
             ValidationFailed(
                 listOf(
-                    "The document is ${doc.document.tracking.status} but it contains the following revisions: ${zeroVersions.map { it.number }.joinToString(", ")}"
+                    "The document is ${doc.document.tracking.status} but it contains the following revisions: ${
+                        zeroVersions.joinToString(", ") { it.number }
+                    }"
                 )
             )
         }
@@ -666,7 +676,9 @@ object Test6119RevisionHistoryEntriesForPreReleaseVersions : Test {
         } else {
             ValidationFailed(
                 listOf(
-                    "The document contains the following pre-release revisions: ${preReleaseVersions.map { it.number }.joinToString(", ")}"
+                    "The document contains the following pre-release revisions: ${
+                        preReleaseVersions.joinToString(", ") { it.number }
+                    }"
                 )
             )
         }


### PR DESCRIPTION
Updated CVSS logic to use `ConfidentialityRequirement1` enums, ensuring accurate mappings for optional metrics.
Fixes #146.
