### PR TITLE
Add fromUrlAsync method and improve CSAF retrieval tests

### DIFF
--- a/csaf-retrieval/src/jvmMain/kotlin/io/github/csaf/sbom/retrieval/RetrievedProvider.kt
+++ b/csaf-retrieval/src/jvmMain/kotlin/io/github/csaf/sbom/retrieval/RetrievedProvider.kt
@@ -168,7 +168,7 @@ data class RetrievedProvider(val json: Provider) : Validatable {
             ioScope.produce<Deferred<Result<RetrievedDocument>>>(capacity = channelCapacity) {
                 for (result in documentUrlChannel) {
                     result.fold(
-                        { send(async { RetrievedDocument.from(it, loader, role) }) },
+                        { send(async { RetrievedDocument.fromUrl(it, loader, role) }) },
                         { send(async { Result.failure(it) }) },
                     )
                 }


### PR DESCRIPTION
Introduced a new `fromUrlAsync` method for asynchronous CSAF document retrieval and validation. Updated tests to use clearer URLs and added new test cases covering asynchronous retrieval via URLs. Refactored existing methods for consistency and improved code clarity.
