### PR TITLE
Refactor exceptions for improved retrieval error handling

### DIFF
--- a/csaf-retrieval/src/commonMain/kotlin/io/github/csaf/sbom/retrieval/RetrievalException.kt
+++ b/csaf-retrieval/src/commonMain/kotlin/io/github/csaf/sbom/retrieval/RetrievalException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, The Authors. All rights reserved.
+ * Copyright (c) 2025, The Authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,16 @@
  * limitations under the License.
  *
  */
-package io.github.csaf.sbom.validation
+package io.github.csaf.sbom.retrieval
 
-/** This exception will be thrown, if the result of a validation is [ValidationFailed]. */
-data class ValidationException(val errors: List<String>) : RuntimeException() {
-    override val message: String
-        get() = "Validation failed with this errors: $errors"
+import io.ktor.client.plugins.ResponseException
+import io.ktor.client.statement.request
+
+class RetrievalException(message: String, cause: Throwable) : RuntimeException(message, cause) {
+    val url: String? =
+        if (cause is ResponseException) {
+            cause.response.request.url.toString()
+        } else {
+            null
+        }
 }

--- a/csaf-retrieval/src/jvmMain/kotlin/io/github/csaf/sbom/retrieval/RetrievedAggregator.kt
+++ b/csaf-retrieval/src/jvmMain/kotlin/io/github/csaf/sbom/retrieval/RetrievedAggregator.kt
@@ -144,7 +144,7 @@ data class RetrievedAggregator(val json: Aggregator) : Validatable {
         }
 
         /**
-         * Retrieves an [Aggregator] from a given [url].
+         * Retrieves an [Aggregator] from a given URL.
          *
          * @param url The URL where to retrieve the [Aggregator] from.
          * @param loader An instance of [CsafLoader].
@@ -160,7 +160,7 @@ data class RetrievedAggregator(val json: Aggregator) : Validatable {
                 .fetchAggregator(url, ctx)
                 .mapCatching { a -> RetrievedAggregator(a).also { it.validate(ctx) } }
                 .recoverCatching { e ->
-                    throw Exception("Failed to load CSAF Aggregator from $url", e)
+                    throw RetrievalException("Failed to load CSAF Aggregator from $url", e)
                 }
         }
     }

--- a/csaf-retrieval/src/jvmMain/kotlin/io/github/csaf/sbom/retrieval/RetrievedDocument.kt
+++ b/csaf-retrieval/src/jvmMain/kotlin/io/github/csaf/sbom/retrieval/RetrievedDocument.kt
@@ -67,7 +67,7 @@ data class RetrievedDocument(
                     }
                 }
                 .recoverCatching { e ->
-                    throw Exception("Failed to load CSAF document from $documentUrl", e)
+                    throw RetrievalException("Failed to load CSAF document from $documentUrl", e)
                 }
         }
 

--- a/csaf-retrieval/src/jvmTest/java/io/github/csaf/sbom/retrieval/RetrievedProviderJavaTest.java
+++ b/csaf-retrieval/src/jvmTest/java/io/github/csaf/sbom/retrieval/RetrievedProviderJavaTest.java
@@ -17,6 +17,8 @@
 package io.github.csaf.sbom.retrieval;
 
 import io.github.csaf.sbom.validation.ValidationException;
+import io.ktor.client.plugins.ResponseException;
+import io.ktor.http.HttpStatusCode;
 import kotlinx.datetime.Instant;
 import org.junit.jupiter.api.Test;
 
@@ -102,11 +104,12 @@ public class RetrievedProviderJavaTest {
         // Check document error
         final var documentError2 = documentResults.get(2).exceptionOrNull();
         assertNotNull(documentError2);
-        final var documentFetchError = (Exception) documentError2.getCause();
+        final var documentFetchError = (ResponseException) documentError2.getCause();
         assertNotNull(documentFetchError);
         assertEquals(
-                "Could not retrieve https://example.com/directory/2024/does-not-exist.json: Not Found",
-                documentFetchError.getMessage()
+                HttpStatusCode.Companion.getNotFound(),
+                documentFetchError.getResponse().getStatus(),
+                "Expected HTTP 404 Not Found"
         );
         // Check index error
         final var indexError = documentResults.get(3).exceptionOrNull();


### PR DESCRIPTION
Replaces generic `Exception` instances with more specific `RetrievalException` and `ResponseException` for better clarity and context in error reporting.
HTTP request errors now directly throw `ResponseException` on non-2xx results, exposing the response/request object and the request URL.
Updates related test cases to reflect these changes, ensuring meaningful validation and assertions for exceptions like `ResponseException`.
