### PR TITLE
Adding `uniqueID` extension function for a `Csaf` document

### DIFF
--- a/csaf-retrieval/src/commonMain/kotlin/io/github/csaf/sbom/retrieval/Extensions.kt
+++ b/csaf-retrieval/src/commonMain/kotlin/io/github/csaf/sbom/retrieval/Extensions.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2025, The Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.github.csaf.sbom.retrieval
+
+import io.github.csaf.sbom.schema.generated.Csaf
+
+/** A platform independent function to compute the SHA-256 hash of a string. */
+expect fun sha256(s: String): ByteArray
+
+/** Returns a hexadecimal representation of the input byte array. */
+fun hex(input: ByteArray): String {
+    return input.joinToString("") { "%02x".format(it) }
+}
+
+/**
+ * This function tries to compute a unique (string-based) ID for a given [Csaf] document. The main
+ * use-case is the usage of this as a primary key in a database.
+ *
+ * In order to compute the ID, we concatenate the following parts (with a dash as separator):
+ * - The prefix "CSAF"
+ * - The first 8 characters of the SHA-256 hash of the publisher namespace
+ * - The tracking ID (which needs to be unique within the publisher namespace)
+ *
+ * @param this the [Csaf] document to compute the ID for.
+ * @return the computed unique ID.
+ */
+val Csaf.uniqueID
+    get(): String {
+        return "CSAF-" +
+            hex(sha256(this.document.publisher.namespace.toString())).substring(0, 8) +
+            "-" +
+            this.document.tracking.id
+    }

--- a/csaf-retrieval/src/jvmMain/kotlin/io/github/csaf/sbom/retrieval/Hash.kt
+++ b/csaf-retrieval/src/jvmMain/kotlin/io/github/csaf/sbom/retrieval/Hash.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2025, The Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.github.csaf.sbom.retrieval
+
+import java.security.MessageDigest
+
+actual fun sha256(s: String): ByteArray {
+    return MessageDigest.getInstance("SHA-256").digest(s.toByteArray())
+}

--- a/csaf-retrieval/src/jvmTest/kotlin/io/github/csaf/sbom/retrieval/ExtensionsTest.kt
+++ b/csaf-retrieval/src/jvmTest/kotlin/io/github/csaf/sbom/retrieval/ExtensionsTest.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2025, The Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.github.csaf.sbom.retrieval
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ExtensionsTest {
+    @Test
+    fun testUniqueID() {
+        val csaf = goodCsaf()
+        assertEquals("CSAF-a379a6f6-test-title", csaf.uniqueID)
+    }
+}

--- a/csaf-schema/src/commonMain/kotlin/io/github/csaf/sbom/schema/JsonTypes.kt
+++ b/csaf-schema/src/commonMain/kotlin/io/github/csaf/sbom/schema/JsonTypes.kt
@@ -19,13 +19,18 @@ package io.github.csaf.sbom.schema
 import kotlinx.datetime.Instant
 import kotlinx.serialization.Serializable
 
+/** A platform independent representation of a URI / URL used in JSON documents. */
 @Serializable(UriSerializer::class)
 expect class JsonUri {
     constructor(s: String)
 
     companion object {
+        /** A platform independent way to create a [JsonUri] from a string. */
         fun create(s: String): JsonUri
     }
+
+    /** The string representation of this [JsonUri], must contain the full URI. */
+    override fun toString(): String
 }
 
 fun epoch(): Instant {

--- a/csaf-schema/src/jvmMain/kotlin/io/github/csaf/sbom/schema/JsonTypes.kt
+++ b/csaf-schema/src/jvmMain/kotlin/io/github/csaf/sbom/schema/JsonTypes.kt
@@ -29,7 +29,7 @@ actual class JsonUri(private var value: URI) {
         }
     }
 
-    override fun toString(): String {
+    actual override fun toString(): String {
         return value.toString()
     }
 


### PR DESCRIPTION
We need a functionality like this in several micro-services of the DependencyTrack integration and it is cleaner to have this upstream. Potentially also useful for other database integrations.
