### PR TITLE
Rename `RetrievedAggregator` factory methods for clarity

### DIFF
--- a/csaf-retrieval/src/jvmMain/kotlin/io/github/csaf/sbom/retrieval/RetrievedAggregator.kt
+++ b/csaf-retrieval/src/jvmMain/kotlin/io/github/csaf/sbom/retrieval/RetrievedAggregator.kt
@@ -134,24 +134,32 @@ data class RetrievedAggregator(val json: Aggregator) : Validatable {
     companion object {
         private val ioScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
+        /**
+         * Retrieves a [RetrievedAggregator] asynchronously from the provided URL.
+         *
+         * @param url The URL to retrieve the aggregator from.
+         * @param loader An optional [CsafLoader] instance. Defaults to [lazyLoader].
+         * @return A [CompletableFuture] that wraps a [RetrievedAggregator] instance upon success,
+         *   or the thrown [Throwable] in case of an error.
+         */
         @JvmStatic
         @JvmOverloads
-        fun fromAsync(
-            domain: String,
+        fun fromUrlAsync(
+            url: String,
             loader: CsafLoader = lazyLoader,
         ): CompletableFuture<RetrievedAggregator> {
-            return ioScope.future { from(domain, loader).getOrThrow() }
+            return ioScope.future { fromUrl(url, loader).getOrThrow() }
         }
 
         /**
-         * Retrieves an [Aggregator] from a given URL.
+         * Retrieves a [RetrievedAggregator] from a given URL.
          *
-         * @param url The URL where to retrieve the [Aggregator] from.
-         * @param loader An instance of [CsafLoader].
+         * @param url The URL to retrieve the [RetrievedAggregator] from.
+         * @param loader An optional [CsafLoader] instance. Defaults to [lazyLoader].
          * @return An instance of [RetrievedAggregator], wrapped in a [Result] monad, if successful.
          *   A failed [Result] wrapping the thrown [Throwable] in case of an error.
          */
-        suspend fun from(
+        suspend fun fromUrl(
             url: String,
             loader: CsafLoader = lazyLoader,
         ): Result<RetrievedAggregator> {

--- a/csaf-retrieval/src/jvmMain/kotlin/io/github/csaf/sbom/retrieval/demo/AggregatorDemo.kt
+++ b/csaf-retrieval/src/jvmMain/kotlin/io/github/csaf/sbom/retrieval/demo/AggregatorDemo.kt
@@ -25,7 +25,7 @@ fun main(args: Array<String>) {
         // Create a new "RetrievedAggregator" from wid.cert-bund.de. This will automatically
         // discover a
         // suitable provider-metadata.json
-        RetrievedAggregator.from(
+        RetrievedAggregator.fromUrl(
                 "https://wid.cert-bund.de/.well-known/csaf-aggregator/aggregator.json"
             )
             .onSuccess { aggregator ->

--- a/csaf-retrieval/src/jvmTest/java/io/github/csaf/sbom/retrieval/RetrievedAggregatorJavaTest.java
+++ b/csaf-retrieval/src/jvmTest/java/io/github/csaf/sbom/retrieval/RetrievedAggregatorJavaTest.java
@@ -39,7 +39,7 @@ public class RetrievedAggregatorJavaTest {
     @Test
     public void testFetchProvidersAsync() throws ExecutionException, InterruptedException {
         final RetrievedAggregator aggregator =
-                RetrievedAggregator.fromAsync("https://example.com/example-01-aggregator.json").get();
+                RetrievedAggregator.fromUrlAsync("https://example.com/example-01-aggregator.json").get();
         CompletableFuture<List<ResultCompat<RetrievedProvider>>> providersFuture = aggregator.fetchProvidersAsync();
         assertNotNull(providersFuture);
         List<ResultCompat<RetrievedProvider>> providers = providersFuture.get();
@@ -50,7 +50,7 @@ public class RetrievedAggregatorJavaTest {
     @Test
     public void testFetchPublishersAsync() throws ExecutionException, InterruptedException {
         final RetrievedAggregator aggregator =
-                RetrievedAggregator.fromAsync("https://example.com/example-01-aggregator.json").get();
+                RetrievedAggregator.fromUrlAsync("https://example.com/example-01-aggregator.json").get();
         CompletableFuture<List<ResultCompat<RetrievedProvider>>> publishersFuture = aggregator.fetchPublishersAsync();
         assertNotNull(publishersFuture);
         List<ResultCompat<RetrievedProvider>> publishers = publishersFuture.get();
@@ -61,7 +61,7 @@ public class RetrievedAggregatorJavaTest {
     @Test
     public void testFetchAllAsync() throws ExecutionException, InterruptedException {
         final RetrievedAggregator aggregator =
-                RetrievedAggregator.fromAsync("https://example.com/example-01-aggregator.json").get();
+                RetrievedAggregator.fromUrlAsync("https://example.com/example-01-aggregator.json").get();
         CompletableFuture<List<ResultCompat<RetrievedProvider>>> allFuture = aggregator.fetchAllAsync();
         assertNotNull(allFuture);
         List<ResultCompat<RetrievedProvider>> allResults = allFuture.get();

--- a/csaf-retrieval/src/jvmTest/kotlin/io/github/csaf/sbom/retrieval/RetrievedAggregatorTest.kt
+++ b/csaf-retrieval/src/jvmTest/kotlin/io/github/csaf/sbom/retrieval/RetrievedAggregatorTest.kt
@@ -36,12 +36,13 @@ class RetrievedAggregatorTest {
 
     @Test
     fun testRetrievedAggregator() = runTest {
-        val lister = RetrievedAggregator.from("https://example.com/example-01-lister.json")
+        val lister = RetrievedAggregator.fromUrl("https://example.com/example-01-lister.json")
         assertTrue(lister.isSuccess)
-        val aggregator = RetrievedAggregator.from("https://example.com/example-01-aggregator.json")
+        val aggregator =
+            RetrievedAggregator.fromUrl("https://example.com/example-01-aggregator.json")
         assertTrue(aggregator.isSuccess)
         val nonExistingLister =
-            RetrievedAggregator.from("https://does-not-exist.com/example-01-lister.json")
+            RetrievedAggregator.fromUrl("https://does-not-exist.com/example-01-lister.json")
         assertTrue(nonExistingLister.isFailure)
     }
 
@@ -65,19 +66,20 @@ class RetrievedAggregatorTest {
 
     @Test
     fun testFetchAll() = runTest {
-        RetrievedAggregator.from("https://example.com/example-01-aggregator.json")
+        RetrievedAggregator.fromUrl("https://example.com/example-01-aggregator.json")
             .getOrThrow()
             .let { aggregator ->
                 val (successes, failures) = aggregator.fetchAll().partition { it.isSuccess }
                 assertEquals(2, successes.size)
                 assertEquals(2, failures.size)
             }
-        RetrievedAggregator.from("https://example.com/example-01-lister.json").getOrThrow().let {
-            lister ->
-            val (successes, failures) = lister.fetchProviders().partition { it.isSuccess }
-            assertEquals(1, successes.size)
-            assertEquals(0, failures.size)
-            assertEquals(0, lister.fetchPublishers().size)
-        }
+        RetrievedAggregator.fromUrl("https://example.com/example-01-lister.json")
+            .getOrThrow()
+            .let { lister ->
+                val (successes, failures) = lister.fetchProviders().partition { it.isSuccess }
+                assertEquals(1, successes.size)
+                assertEquals(0, failures.size)
+                assertEquals(0, lister.fetchPublishers().size)
+            }
     }
 }


### PR DESCRIPTION
Refactored factory method names in `RetrievedAggregator` for better readability and consistency. Changed `from` to `fromUrl` and `fromAsync` to `fromUrlAsync` across Kotlin and Java files. Updated relevant tests and documentation accordingly.
