### PR TITLE
Add exponential backoff to http client

### DIFF
--- a/csaf-retrieval/src/commonMain/kotlin/io/csaf/retrieval/CsafLoader.kt
+++ b/csaf-retrieval/src/commonMain/kotlin/io/csaf/retrieval/CsafLoader.kt
@@ -50,7 +50,8 @@ fun defaultHttpClient(engine: HttpClientEngine = defaultHttpClientEngine()): Htt
             retryOnServerErrors(maxRetries = 3)
             // Retry on HTTP Too Many Requests
             retryIf(maxRetries = 3) { _, response -> response.status.value == 429 }
-            // Use default exponential backoff
+            // Use exponential backoff
+            exponentialDelay()
         }
     }
 }


### PR DESCRIPTION
After the MR was merged, I looked into the documentation of ktor some more. I'm not too familiar with kotlin or ktor, but it seems the default exponential delay config isn't respected when you configure the plugin yourself.

This PR explicitly configures the exponential delay option.

It also automatically supports the Retry-After header, which should help with 429 errors. 