### PR TITLE
Set GRADLE_OPTS environment variable in CI

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -82,6 +82,7 @@ jobs:
         ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PASSWORD }}
         ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
         ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+        GRADLE_OPTS: "-Xmx2g -XX:MaxMetaspaceSize=1g"
 
   dependency-submission:
     if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
Add `GRADLE_OPTS` with memory settings to the Gradle CI workflow for improved build stability and performance.