### PR TITLE
Use `gradle.properties` to fix OOM Exception

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -82,7 +82,6 @@ jobs:
         ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PASSWORD }}
         ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
         ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
-        GRADLE_OPTS: "-Xmx2g -XX:MaxMetaspaceSize=1g"
 
   dependency-submission:
     if: github.ref == 'refs/heads/main'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
+org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g -Dkotlin.daemon.jvm.options=-Xmx4g
 kotlin.code.style=official


### PR DESCRIPTION
Fix memory settings of the Gradle CI workflow for improved build stability and performance.