### PR TITLE
Add helpful constructors to CsafLoader

### DIFF
--- a/csaf-retrieval/src/commonMain/kotlin/io/csaf/retrieval/CsafLoader.kt
+++ b/csaf-retrieval/src/commonMain/kotlin/io/csaf/retrieval/CsafLoader.kt
@@ -40,18 +40,35 @@ expect fun defaultHttpClientEngine(): HttpClientEngine
  * Creates a default [HttpClient] with retry logic and JSON support.
  *
  * @param engine The HTTP engine to use. Defaults to [defaultHttpClientEngine].
+ * @param maxRetries The amount of times that HTTP requests are retried on errors.
+ * @param retryBase The exponent for exponential delay.
+ * @param retryBaseDelayMs Base delay in ms.
+ * @param retryMaxDelayMs Max delay in ms.
+ * @return Configured [HttpClient].
  */
-fun defaultHttpClient(engine: HttpClientEngine = defaultHttpClientEngine()): HttpClient {
+@JvmOverloads
+fun defaultHttpClient(
+    engine: HttpClientEngine = defaultHttpClientEngine(),
+    maxRetries: Int = 3,
+    retryBase: Double = 2.0,
+    retryBaseDelayMs: Long = 1000,
+    retryMaxDelayMs: Long = 60000,
+): HttpClient {
     return HttpClient(engine) {
         expectSuccess = true
+
         install(ContentNegotiation) { json() }
 
         install(HttpRequestRetry) {
-            retryOnServerErrors(maxRetries = 3)
+            retryOnServerErrors(maxRetries = maxRetries)
             // Retry on HTTP Too Many Requests
-            retryIf(maxRetries = 3) { _, response -> response.status.value == 429 }
+            retryIf(maxRetries = maxRetries) { _, response -> response.status.value == 429 }
             // Use exponential backoff
-            exponentialDelay()
+            exponentialDelay(
+                base = retryBase,
+                baseDelayMs = retryBaseDelayMs,
+                maxDelayMs = retryMaxDelayMs,
+            )
         }
     }
 }
@@ -184,7 +201,51 @@ constructor(engine: HttpClientEngine? = null, client: HttpClient? = null) {
             }
 
     companion object {
-        val lazyLoader: CsafLoader by lazy { defaultLoaderFactory() }
+        @JvmStatic val lazyLoader: CsafLoader by lazy { defaultLoaderFactory() }
         internal var defaultLoaderFactory: (() -> CsafLoader) = { CsafLoader() }
+
+        /**
+         * Initialize a [CsafLoader] with the provided [HttpClient].
+         *
+         * @param client [HttpClient] used for preforming requests.
+         */
+        @JvmStatic fun fromClient(client: HttpClient): CsafLoader = CsafLoader(client = client)
+
+        /**
+         * Initialize a [CsafLoader] with the provided [HttpClientEngine].
+         *
+         * @param engine [HttpClientEngine] passed to default [HttpClient].
+         */
+        @JvmStatic
+        fun fromEngine(engine: HttpClientEngine): CsafLoader = CsafLoader(engine = engine)
+
+        /**
+         * Initialize a [CsafLoader] with the provided settings.
+         *
+         * @param maxRetries The amount of times that HTTP requests are retried on errors.
+         * @param retryBase The exponent for exponential delay.
+         * @param retryBaseDelayMs Base delay in ms.
+         * @param retryMaxDelayMs Max delay in ms.
+         * @param engine The HTTP engine to use. Defaults to [defaultHttpClientEngine].
+         */
+        @JvmStatic
+        @JvmOverloads
+        fun withSettings(
+            maxRetries: Int = 3,
+            retryBase: Double = 2.0,
+            retryBaseDelayMs: Long = 1000,
+            retryMaxDelayMs: Long = 60000,
+            engine: HttpClientEngine? = null,
+        ): CsafLoader =
+            CsafLoader(
+                client =
+                    defaultHttpClient(
+                        engine = engine ?: defaultHttpClientEngine(),
+                        maxRetries = maxRetries,
+                        retryBase = retryBase,
+                        retryBaseDelayMs = retryBaseDelayMs,
+                        retryMaxDelayMs = retryMaxDelayMs,
+                    )
+            )
     }
 }

--- a/csaf-retrieval/src/jvmTest/java/io/csaf/retrieval/CsafLoaderJavaTest.java
+++ b/csaf-retrieval/src/jvmTest/java/io/csaf/retrieval/CsafLoaderJavaTest.java
@@ -1,0 +1,65 @@
+package io.csaf.retrieval;
+
+import io.ktor.client.HttpClient;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class CsafLoaderJavaTest {
+
+    @Test
+    void testDefaultConstructor() {
+        // Should not crash, default engine + client inside
+        CsafLoader loader = new CsafLoader();
+        assertNotNull(loader);
+    }
+
+    @Test
+    void testConstructorWithEngine() {
+        CsafLoader loader = new CsafLoader(TestUtilsKt.mockEngine());
+        assertNotNull(loader);
+    }
+
+    @Test
+    void testConstructorWithClient() {
+        HttpClient client = CsafLoaderKt.defaultHttpClient(TestUtilsKt.mockEngine());
+        CsafLoader loader = new CsafLoader(null, client);
+        assertNotNull(loader);
+    }
+
+    @Test
+    void testFactoryFromClient() {
+        HttpClient client = CsafLoaderKt.defaultHttpClient(TestUtilsKt.mockEngine());
+        CsafLoader loader = CsafLoader.fromClient(client);
+        assertNotNull(loader);
+    }
+
+    @Test
+    void testFactoryFromEngine() {
+        CsafLoader loader = CsafLoader.fromEngine(TestUtilsKt.mockEngine());
+        assertNotNull(loader);
+    }
+
+    @Test
+    void testFactoryWithSettings() {
+        CsafLoader loader = CsafLoader.withSettings();
+        assertNotNull(loader);
+    }
+
+    @Test
+    void testFactoryWithSettingsAllArgs() {
+        CsafLoader loader = CsafLoader.withSettings(
+                10,   // maxRetries
+                3.0,  // retryBase
+                500,  // retryBaseDelayMs
+                20000, // retryMaxDelayMs
+                TestUtilsKt.mockEngine() // engine
+        );
+        assertNotNull(loader);
+    }
+
+    @Test
+    void testGetLazyLoader() {
+        CsafLoader loader = CsafLoader.getLazyLoader();
+        assertNotNull(loader);
+    }
+}

--- a/csaf-retrieval/src/jvmTest/kotlin/io/csaf/retrieval/CsafLoaderTest.kt
+++ b/csaf-retrieval/src/jvmTest/kotlin/io/csaf/retrieval/CsafLoaderTest.kt
@@ -49,8 +49,31 @@ class CsafLoaderTest {
     }
 
     @Test
+    fun testFromEngineConstructorHelper() {
+        assertNotNull(CsafLoader.fromEngine(mockEngine()))
+    }
+
+    @Test
     fun testSupplyClientToCsafLoader() {
         assertNotNull(CsafLoader(null, defaultHttpClient(mockEngine())))
+    }
+
+    @Test
+    fun testFromClientConstructorHelper() {
+        assertNotNull(CsafLoader.fromClient(defaultHttpClient(mockEngine())))
+    }
+
+    @Test
+    fun testWithSettingsConstructorHelper() {
+        assertNotNull(
+            CsafLoader.withSettings(
+                maxRetries = 1,
+                retryBase = 3.0,
+                retryBaseDelayMs = 5000,
+                retryMaxDelayMs = 100000,
+                engine = mockEngine(),
+            )
+        )
     }
 
     @Test
@@ -157,6 +180,7 @@ class CsafLoaderTest {
     @Test
     fun testRestriesAreLimited() = runTest {
         val loader = CsafLoader(tooManyRequestsEngineFactory(4))
+
         val result =
             loader.fetchText("does-not-exist.com/too-many-requests.txt") {
                 assertSame(HttpStatusCode.TooManyRequests, it.status)


### PR DESCRIPTION
While testing DependencyTrack with the CSAF from vulnerabilities.ncsc.nl, we noticed that it is very difficult to change the http client from a java project.

Due to the way that the ktor http plugins are configured (blocks/closures/not sure of the name), trying to initialize a ktor http client from java is extremely tedious.

In this PR, I've added new, helpful static methods which allow a user to easily change the configuration of the http client retry plugin from both Kotlin and Java.

This change retains the previously released constructors (and overloads), so it is backwards compatible.